### PR TITLE
Sources must provide the message timestamp

### DIFF
--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSource.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSource.scala
@@ -142,7 +142,8 @@ object KinesisSource {
           .view
           .mapValues(_.maxBy(_.sequenceNumber).toMetadata[F])
           .toMap
-        LowLevelEvents(chunk.toList.map(_.record.data()), ack)
+        val earliestTstamp = chunk.iterator.map(_.record.approximateArrivalTimestamp).minOption
+        LowLevelEvents(chunk.toList.map(_.record.data()), ack, earliestTstamp)
       }
   }
 

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/TokenedEvents.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/TokenedEvents.scala
@@ -10,6 +10,7 @@ package com.snowplowanalytics.snowplow.sources
 import cats.effect.kernel.Unique
 
 import java.nio.ByteBuffer
+import java.time.Instant
 
 /**
  * The events as they are fed into a [[EventProcessor]]
@@ -20,5 +21,12 @@ import java.nio.ByteBuffer
  *   The [[EventProcessor]] must emit this token after it has fully processed the batch of events.
  *   When the [[EventProcessor]] emits the token, it is an instruction to the [[SourceAndAck]] to
  *   ack/checkpoint the events.
+ * @param earliestSourceTstamp
+ *   The timestamp that an event was originally written to the source stream. Used for calculating
+ *   the latency metric.
  */
-case class TokenedEvents(events: List[ByteBuffer], ack: Unique.Token)
+case class TokenedEvents(
+  events: List[ByteBuffer],
+  ack: Unique.Token,
+  earliestSourceTstamp: Option[Instant]
+)

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelEvents.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelEvents.scala
@@ -8,6 +8,7 @@
 package com.snowplowanalytics.snowplow.sources.internal
 
 import java.nio.ByteBuffer
+import java.time.Instant
 
 /**
  * The events and checkpointable item emitted by a LowLevelSource
@@ -15,4 +16,8 @@ import java.nio.ByteBuffer
  * This library uses LowLevelEvents internally, but it is never exposed to the high level event
  * processor
  */
-case class LowLevelEvents[C](events: List[ByteBuffer], ack: C)
+case class LowLevelEvents[C](
+  events: List[ByteBuffer],
+  ack: C,
+  earliestSourceTstamp: Option[Instant]
+)


### PR DESCRIPTION
We need our apps to report a latency metric, which is defined as:

```
latency =
 {time event was processed} - {time event was written to input stream }
```

This metric will be used to create an alarm when the app is lagging.

Currently our applications cannot report this metric, because they do not know the time the event was written to the input stream.  This PR adds a timestamp to the `TokenedEvents` case class, which is the class that gets passed to the application.