### PR TITLE
Publish independent runtime-common module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     strategy:
       matrix:
-        module: [ "streams-core", "kinesis", "kafka", "pubsub", "loaders-common"]
+        module: [ "streams-core", "kinesis", "kafka", "pubsub", "loaders-common", "runtime-common"]
 
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ lazy val root = project
     kinesisIT,
     kafka,
     pubsub,
+    runtimeCommon,
     loadersCommon
   )
 
@@ -95,6 +96,23 @@ lazy val pubsub: Project = project
   .settings(libraryDependencies ++= Dependencies.pubsubDependencies)
   .dependsOn(streams)
 
+lazy val runtimeCommon: Project = project
+  .settings(
+    name := "runtime-common"
+  )
+  .withId("runtime-common")
+  .in(file("modules/runtime-common"))
+  .enablePlugins(SiteScaladocPlugin, PreprocessPlugin, SitePreviewPlugin)
+  .settings(BuildSettings.buildSettings)
+  .settings(BuildSettings.publishSettings)
+  .settings(BuildSettings.mimaSettings)
+  .settings(BuildSettings.docsSettings)
+  .settings(
+    previewFixedPort := Some(9994),
+    Preprocess / preprocessVars := Map("VERSION" -> version.value)
+  )
+  .settings(libraryDependencies ++= Dependencies.runtimeCommonDependencies)
+
 lazy val loadersCommon: Project = project
   .settings(
     name := "loaders-common"
@@ -118,6 +136,7 @@ val StreamsCore   = config("streams-core")
 val Kinesis       = config("kinesis")
 val Kafka         = config("kafka")
 val PubSub        = config("pubsub")
+val RuntimeCommon = config("runtime-common")
 val LoadersCommon = config("loaders-common")
 
 lazy val scaladocSiteProjects: List[(Project, sbt.Configuration)] = List(
@@ -125,6 +144,7 @@ lazy val scaladocSiteProjects: List[(Project, sbt.Configuration)] = List(
   (kinesis, Kinesis),
   (kafka, Kafka),
   (pubsub, PubSub),
+  (runtimeCommon, RuntimeCommon),
   (loadersCommon, LoadersCommon)
 )
 

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/AppInfo.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/AppInfo.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 trait AppInfo {
   def name: String

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/ConfigParser.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/ConfigParser.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 import cats.data.EitherT
 import cats.effect.Sync

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/HealthProbe.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/HealthProbe.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 import cats.effect.{Async, Resource, Sync}
 import cats.data.Kleisli

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/LogUtils.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/LogUtils.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 import org.typelevel.log4cats.Logger
 

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Metrics.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Metrics.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 import cats.effect.{Async, Sync}
 import cats.effect.kernel.{Ref, Resource}

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Telemetry.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Telemetry.scala
@@ -5,7 +5,7 @@
  * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
  * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
  */
-package com.snowplowanalytics.snowplow.loaders.runtime
+package com.snowplowanalytics.snowplow.runtime
 
 import cats.data.NonEmptyList
 import cats.effect.{Async, Resource, Sync}

--- a/modules/runtime-common/src/site-preprocess/index.html
+++ b/modules/runtime-common/src/site-preprocess/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Project Documentation</title>
+    <script type="JavaScript">
+    <!--
+    function doRedirect()
+    {
+        window.location.replace("@VERSION@");
+    }
+    doRedirect();
+    //-->
+    </script>
+</head>
+<body>
+<a href="@VERSION@">Go to the project documentation
+</a>
+</body>
+</html>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -154,23 +154,29 @@ object Dependencies {
     collectionCompat
   )
 
+  val runtimeCommonDependencies = Seq(
+    cats,
+    catsEffectKernel,
+    circeConfig,
+    emberServer,
+    fs2,
+    igluClient,
+    log4cats,
+    slf4jApi,
+    tracker,
+    trackerEmit
+  )
+
   val loadersCommonDependencies = Seq(
     cats,
     catsEffectKernel,
     schemaDdl,
     badrows,
-    circeConfig,
     circeLiteral % Test,
-    emberServer,
-    fs2,
     igluClient,
-    log4cats,
-    tracker,
-    trackerEmit,
     analyticsSdk,
     specs2,
     catsEffectSpecs2,
-    slf4jApi,
     slf4jSimple % Test
   )
 }


### PR DESCRIPTION
With this change, this is the complete list of maven assets produced by this repo:

- `com.snowplowanalytics:streams-core_2.13`
- `com.snowplowanalytics:kinesis_2.13`
- `com.snowplowanalytics:pubsub_2.13`
- `com.snowplowanalytics:kafka_2.13`
- `com.snowplowanalytics:runtime-common_2.13`
- `com.snowplowanalytics:loaders-common_2.13`

(...plus same again for 2.12)