### PR TITLE
Fix sporadically failing latency test

### DIFF
--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/CleanCancellation.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/CleanCancellation.scala
@@ -70,7 +70,7 @@ object CleanCancellation {
       .concurrently {
         Stream.bracket(().pure[F])(_ => sig.complete(()).void) >>
           Stream
-            .fromQueueNoneTerminated(queue)
+            .fromQueueNoneTerminated(queue, 1)
             .through(sinkAndCheckpoint)
             .onFinalizeCase {
               case ExitCase.Succeeded =>


### PR DESCRIPTION
This one is hard to explain, but I am satisfied this is the correct fix.

This part of the code uses a "synchronous" queue, which basically means a queue of size zero, i.e. we are blocked from writing to the queue until a consumer is ready to read from it ([documentation](https://github.com/typelevel/cats-effect/blob/v3.5.2/std/shared/src/main/scala/cats/effect/std/Queue.scala#L108-L119)).

For that reason, when we read from the queue, the `Chunk` we receive should only contain a single item (single batch of events).

But... during tests we mess around with time and we hit race conditions which are possible during tests but vanishingly unlikely in real scenarios!  There is an edge case where fs2 pulls a Chunk comprising >1 item from this queue, because there is something writing to the queue at exactly the same time.

The solution (to satisfy the tests) is to explicitly only ever pull a single item from the queue.  This does not affect how it works in real life, because we only expect to receive a single item anyway.