### PR TITLE
Remove maxRetries from kinesis sink config

### DIFF
--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSink.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSink.scala
@@ -247,12 +247,7 @@ object KinesisSink {
   private object Retries {
 
     def fibonacci[F[_]: Applicative](config: BackoffPolicy): RetryPolicy[F] =
-      capBackoffAndRetries(config, RetryPolicies.fibonacciBackoff[F](config.minBackoff))
-
-    private def capBackoffAndRetries[F[_]: Applicative](config: BackoffPolicy, policy: RetryPolicy[F]): RetryPolicy[F] = {
-      val capped = RetryPolicies.capDelay[F](config.maxBackoff, policy)
-      config.maxRetries.fold(capped)(max => capped.join(RetryPolicies.limitRetries(max)))
-    }
+      RetryPolicies.capDelay[F](config.maxBackoff, RetryPolicies.fibonacciBackoff[F](config.minBackoff))
   }
 
   private def getRecordSize(record: PutRecordsRequestEntry) =

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSinkConfig.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSinkConfig.scala
@@ -16,8 +16,7 @@ import java.net.URI
 
 case class BackoffPolicy(
   minBackoff: FiniteDuration,
-  maxBackoff: FiniteDuration,
-  maxRetries: Option[Int]
+  maxBackoff: FiniteDuration
 )
 
 object BackoffPolicy {


### PR DESCRIPTION
Previously `maxRetries` was optional.  If an app is throttled for more than the `maxRetries` limit then it would raise an exception, the app would crash and exit.

But, in a situation when we are being throttled,  I cannot think of any circumstance where it is helpful to crash and restart.  I would prefer to make this non-configurable, so it makes the code simpler and forces us to configure apps properly instead of making bad decisions in the hocon files.

Admittedly we might want to protect against _extreme_ scenarios where an app is unexpectedly throttled much more than expected.  But we already have things like health probes and latency alarms to protect against that in production.