### PR TITLE
Use short `_schema_version` field from analytics-sdk

### DIFF
--- a/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/SkippingSchemasSpec.scala
+++ b/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/SkippingSchemasSpec.scala
@@ -47,11 +47,11 @@ class SkippingSchemasSpec extends Specification {
         NamedValue(name = "unstruct_event_com_example_my_schema_1", value = json"""{"field": "ue1"}"""),
         NamedValue(
           name  = "contexts_com_example_my_schema_2",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-0-0", "field": "c1"}]"""
+          value = json"""[{"_schema_version" : "2-0-0", "field": "c1"}]"""
         ),
         NamedValue(
           name  = "contexts_com_example_my_schema_3",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/3-0-0", "field": "dc1"}]"""
+          value = json"""[{"_schema_version" : "3-0-0", "field": "dc1"}]"""
         )
       )
     )
@@ -72,11 +72,11 @@ class SkippingSchemasSpec extends Specification {
         NamedValue(name = "unstruct_event_com_example_my_schema_1", value = json"""{"field": "ue1"}"""),
         NamedValue(
           name  = "contexts_com_example_my_schema_2",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-0-0", "field": "c1"}]"""
+          value = json"""[{"_schema_version" : "2-0-0", "field": "c1"}]"""
         ),
         NamedValue(
           name  = "contexts_com_example_my_schema_3",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/3-0-0", "field": "dc1"}]"""
+          value = json"""[{"_schema_version" : "3-0-0", "field": "dc1"}]"""
         )
       )
     )
@@ -117,11 +117,11 @@ class SkippingSchemasSpec extends Specification {
       shouldExist = List(
         NamedValue(
           name  = "contexts_com_example_my_schema_2",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-0-0", "field": "c1"}]"""
+          value = json"""[{"_schema_version" : "2-0-0", "field": "c1"}]"""
         ),
         NamedValue(
           name  = "contexts_com_example_my_schema_3",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/3-0-0", "field": "dc1"}]"""
+          value = json"""[{"_schema_version" : "3-0-0", "field": "dc1"}]"""
         )
       )
     )
@@ -147,11 +147,11 @@ class SkippingSchemasSpec extends Specification {
         // There is still '_2' column because 2-0-0 is skipped, but 2-1-0 with c2 value is not
         NamedValue(
           name  = "contexts_com_example_my_schema_2",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-1-0", "field": "c2"}]"""
+          value = json"""[{"_schema_version" : "2-1-0", "field": "c2"}]"""
         ),
         NamedValue(
           name  = "contexts_com_example_my_schema_3",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/3-0-0", "field": "dc1"}]"""
+          value = json"""[{"_schema_version" : "3-0-0", "field": "dc1"}]"""
         )
       )
     )
@@ -177,8 +177,8 @@ class SkippingSchemasSpec extends Specification {
         NamedValue(name = "unstruct_event_com_example_my_schema_1", value = json"""{"field": "ue1"}"""),
         NamedValue(
           name = "contexts_com_example_my_schema_2",
-          value = json"""[{"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-0-0", "field": "c1"}, 
-                          {"_schema_version" : "iglu:com.example/mySchema/jsonschema/2-1-0", "field": "c2"}]"""
+          value = json"""[{"_schema_version" : "2-0-0", "field": "c1"}, 
+                          {"_schema_version" : "2-1-0", "field": "c2"}]"""
         )
       )
     )

--- a/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/TransformSpec.scala
+++ b/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/TransformSpec.scala
@@ -178,7 +178,7 @@ class TransformSpec extends Specification {
         name = "contexts_com_example_my_schema_7",
         value = json"""
               [{
-                "_schema_version" : "iglu:com.example/mySchema/jsonschema/7-0-1",
+                "_schema_version" : "7-0-1",
                 "my_string": "abc",
                 "my_int":     42
               }]
@@ -188,7 +188,7 @@ class TransformSpec extends Specification {
         name = "contexts_com_example_my_schema_8",
         value = json"""
               [{
-                "_schema_version" : "iglu:com.example/mySchema/jsonschema/8-0-1",
+                "_schema_version" : "8-0-1",
                 "my_string": "xyz",
                 "my_int":     123 
               }]
@@ -237,12 +237,12 @@ class TransformSpec extends Specification {
       name = "contexts_com_example_my_schema_7",
       value = json"""
             [{
-              "_schema_version" : "iglu:com.example/mySchema/jsonschema/7-0-1",
+              "_schema_version" : "7-0-1",
               "my_string": "abc",
               "my_int":     42
             },
             {
-              "_schema_version" : "iglu:com.example/mySchema/jsonschema/7-0-2",
+              "_schema_version" : "7-0-2",
               "my_string": "xyz",
               "my_int":     123 
             }]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -42,7 +42,7 @@ object Dependencies {
     val badrows      = "2.3.0"
     val igluClient   = "3.1.0"
     val tracker      = "2.0.0"
-    val analyticsSdk = "3.2.0"
+    val analyticsSdk = "3.2.1"
 
     // Transitive overrides
     val snappy = "1.1.10.2"


### PR DESCRIPTION
By using new 3.2.1 analytics-sdk version and this change -> https://github.com/snowplow/snowplow-scala-analytics-sdk/pull/134