### PR TITLE
Use `Vector` instead of `List` in transform methods

### DIFF
--- a/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/TransformSpec.scala
+++ b/modules/loaders-common/src/test/scala/com.snowplowanalytics.snowplow.loaders/transform/TransformSpec.scala
@@ -53,7 +53,7 @@ class TransformSpec extends Specification {
       NamedValue("geo_region", Json.Null)
     )
 
-    result must beRight { namedValues: List[NamedValue[Json]] =>
+    result must beRight { namedValues: Vector[NamedValue[Json]] =>
       expected
         .map { e =>
           namedValues must contain(e).exactly(1.times)
@@ -85,7 +85,7 @@ class TransformSpec extends Specification {
       NamedValue("tr_total", Json.fromDoubleOrNull(12.34))
     )
 
-    result must beRight { namedValues: List[NamedValue[Json]] =>
+    result must beRight { namedValues: Vector[NamedValue[Json]] =>
       expected
         .map { e =>
           namedValues must contain(e).exactly(1.times)
@@ -140,7 +140,7 @@ class TransformSpec extends Specification {
 
     val expected = NamedValue("unstruct_event_com_example_my_schema_7", data)
 
-    result must beRight { namedValues: List[NamedValue[Json]] =>
+    result must beRight { namedValues: Vector[NamedValue[Json]] =>
       namedValues must contain(expected).exactly(1.times)
     }
   }
@@ -196,7 +196,7 @@ class TransformSpec extends Specification {
       )
     )
 
-    result must beRight { namedValues: List[NamedValue[Json]] =>
+    result must beRight { namedValues: Vector[NamedValue[Json]] =>
       expected
         .map { e =>
           namedValues must contain(e).exactly(1.times)
@@ -249,7 +249,7 @@ class TransformSpec extends Specification {
             """
     )
 
-    result must beRight { namedValues: List[NamedValue[Json]] =>
+    result must beRight { namedValues: Vector[NamedValue[Json]] =>
       namedValues must contain(expected).exactly(1.times)
     }
   }


### PR DESCRIPTION
Currently, the transform functions in common-loaders return a [List](https://github.com/snowplow-incubator/common-streams/blob/0.2.1/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/Transform.scala#L83).  We construct the list by concatenating two lists: 1 for atomic fields and 1 for the self-describing entity fields ([this line](https://github.com/snowplow-incubator/common-streams/blob/0.2.1/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/Transform.scala#L86)).

The `:::` operator is relatively expensive, especially for large lists.  And this is a “hot” function which we invoke for every single event.

If we switch the implementation to use Vector instead of List then it should be much more efficient to concatenate the two lists.