### PR TITLE
Fix nacking unhandled pubsub messages during shutdown

### DIFF
--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
@@ -86,8 +86,8 @@ private[sources] object LowLevelSource {
   ): SourceAndAck[F] = new SourceAndAck[F] {
     def stream(config: EventProcessingConfig, processor: EventProcessor[F]): Stream[F, Nothing] = {
       val str = for {
-        acksRef <- Stream.bracket(Ref[F].of(Map.empty[Unique.Token, C]))(nackUnhandled(source.checkpointer, _))
         s2 <- source.stream
+        acksRef <- Stream.bracket(Ref[F].of(Map.empty[Unique.Token, C]))(nackUnhandled(source.checkpointer, _))
         _ <- Stream.bracket(isConnectedRef.set(true))(_ => isConnectedRef.set(false))
       } yield {
         val tokenedSources = s2


### PR DESCRIPTION
The LowLevelSource maintains a list of what messages are in-flight but not yet acked. During graceful shutdown, it should nack everything in this list so that Pubsub can quickly re-send the messages to another pod. But because of a subtle bug, the pubsub Subscriber was getting shutdown before those messages got nacked.