### PR TITLE
Use `Vector` instead of `List` in transform methods: part 2

### DIFF
--- a/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/NonAtomicFields.scala
+++ b/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/NonAtomicFields.scala
@@ -28,7 +28,7 @@ object NonAtomicFields {
    *   details of schemas that were present in the batch but could not be looked up by the Iglu
    *   resolver.
    */
-  case class Result(fields: List[TypedTabledEntity], igluFailures: List[ColumnFailure])
+  case class Result(fields: Vector[TypedTabledEntity], igluFailures: List[ColumnFailure])
 
   /**
    * Describes a failure to lookup a series of Iglu schemas
@@ -51,7 +51,7 @@ object NonAtomicFields {
     entities: Map[TabledEntity, Set[SchemaSubVersion]],
     filterCriteria: List[SchemaCriterion]
   ): F[Result] =
-    entities.toList
+    entities.toVector
       .map { case (tabledEntity, subVersions) =>
         // First phase of entity filtering, before we fetch schemas from Iglu and create `TypedTabledEntity`.
         // If all sub-versions are filtered out, whole family is removed.
@@ -78,7 +78,7 @@ object NonAtomicFields {
       }
       .map { eithers =>
         val (failures, good) = eithers.separate
-        Result(good, failures)
+        Result(good, failures.toList)
       }
 
   private def filterSubVersions(

--- a/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/Transform.scala
+++ b/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/Transform.scala
@@ -47,7 +47,7 @@ object Transform {
     batchInfo: NonAtomicFields.Result
   ): Either[BadRow, Vector[Caster.NamedValue[A]]] =
     failForResolverErrors(processor, event, batchInfo.igluFailures) *>
-      (forAtomic(caster, event), forEntities(caster, event, batchInfo.fields.toVector))
+      (forAtomic(caster, event), forEntities(caster, event, batchInfo.fields))
         .mapN { case (atomic, nonAtomic) =>
           atomic ++ nonAtomic
         }


### PR DESCRIPTION
In #62 the transform method was improved to avoid the expensive `:::` operator.  But we were still converting a `List` to a `Vector` for every single event.  That conversion can be eliminated fairly easily.