### PR TITLE
Manually fetch container image before running StatsD spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,11 @@ jobs:
         with:
           java-version: 11
 
-      - name: Download test requirements
-        run: |
-          docker pull testcontainers/ryuk:0.5.1
-          docker pull localstack/localstack:2.3.2
-
       - name: Check Scala formatting
         run: sbt scalafmtSbtCheck scalafmtCheckAll
 
       - name: Run tests
-        run: sbt clean +test
+        run: env TESTCONTAINERS_RYUK_DISABLED=true sbt clean +test
 
       - name: Check binary compatibility
         run: sbt mimaReportBinaryIssues

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/DockerPull.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/DockerPull.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.it
+
+import com.github.dockerjava.core.DockerClientBuilder
+import com.github.dockerjava.api.command.PullImageResultCallback
+import com.github.dockerjava.api.model.PullResponseItem
+
+object DockerPull {
+
+  /**
+   * A blocking operation that runs on main thread to pull container image before `CatsResource` is
+   * created. This operation is then not counted towards test timeout.
+   *
+   * @param image
+   * @param tag
+   */
+  def pull(image: String, tag: String): Unit =
+    DockerClientBuilder
+      .getInstance()
+      .build()
+      .pullImageCmd(image)
+      .withTag(tag)
+      .withPlatform("linux/amd64")
+      .exec(new PullImageResultCallback() {
+        override def onNext(item: PullResponseItem) = {
+          println(s"$image: ${item.getStatus()}")
+          super.onNext(item)
+        }
+      })
+      .awaitCompletion()
+      .onComplete()
+
+}

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/MetricsSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/MetricsSpec.scala
@@ -14,31 +14,15 @@ import cats.effect.testing.specs2.CatsResource
 import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.BeforeAll
 import org.testcontainers.containers.GenericContainer
-import com.github.dockerjava.core.DockerClientBuilder
-import com.github.dockerjava.api.command.PullImageResultCallback
+import com.snowplowanalytics.snowplow.it.DockerPull
 
 import retry.syntax.all._
 import retry.RetryPolicies
-import com.github.dockerjava.api.model.PullResponseItem
 
 class MetricsSpec extends CatsResource[IO, (GenericContainer[_], StatsdAPI[IO])] with SpecificationLike with BeforeAll {
 
   override def beforeAll(): Unit = {
-    // blocking the main thread to fetch before we start creating a container
-    DockerClientBuilder
-      .getInstance()
-      .build()
-      .pullImageCmd(Statsd.image)
-      .withTag(Statsd.tag)
-      .withPlatform("linux/amd64")
-      .exec(new PullImageResultCallback() {
-        override def onNext(item: PullResponseItem) = {
-          println(s"StatsD image: ${item.getStatus()}")
-          super.onNext(item)
-        }
-      })
-      .awaitCompletion()
-      .onComplete()
+    DockerPull.pull(Statsd.image, Statsd.tag)
     super.beforeAll()
   }
 

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/Statsd.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/Statsd.scala
@@ -17,12 +17,13 @@ import com.github.dockerjava.api.model.ExposedPort
 import com.github.dockerjava.api.model.Ports
 
 object Statsd {
-
+  val image = "dblworks/statsd" // the official statsd/statsd size is monstrous
+  val tag   = "v0.10.1"
   def resource(
     loggerName: String
   ): Resource[IO, GenericContainer[_]] =
     Resource.make {
-      val statsd: GenericContainer[_] = new GenericContainer("statsd/statsd:v0.10.1")
+      val statsd: GenericContainer[_] = new GenericContainer(s"$image:$tag")
       statsd.addExposedPort(8126)
       statsd.setWaitStrategy(Wait.forLogMessage("""^(.*)server is up(.+)$""", 1))
       statsd.withCreateContainerCmdModifier { cmd =>
@@ -33,7 +34,7 @@ object Statsd {
         cmd.getHostConfig().withPortBindings(ports)
         ()
       }
-      IO(start(statsd, loggerName))
+      IO.blocking(start(statsd, loggerName))
     }(ls => IO.blocking(ls.stop()))
 
   private def start(statsd: GenericContainer[_], loggerName: String): GenericContainer[_] = {

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSinkSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSinkSpec.scala
@@ -19,15 +19,21 @@ import org.testcontainers.containers.localstack.LocalStackContainer
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 import software.amazon.awssdk.regions.Region
 
+import com.snowplowanalytics.snowplow.it.DockerPull
 import com.snowplowanalytics.snowplow.it.kinesis._
 import com.snowplowanalytics.snowplow.sinks.{ListOfList, Sink, Sinkable}
 
 import Utils._
+import org.specs2.specification.BeforeAll
 
-class KinesisSinkSpec extends CatsResource[IO, (Region, LocalStackContainer, Sink[IO])] with SpecificationLike {
+class KinesisSinkSpec extends CatsResource[IO, (Region, LocalStackContainer, Sink[IO])] with SpecificationLike with BeforeAll {
   import KinesisSinkSpec._
 
   override val Timeout: FiniteDuration = 3.minutes
+  override def beforeAll(): Unit = {
+    DockerPull.pull(Localstack.image, Localstack.tag)
+    super.beforeAll()
+  }
 
   /** Resources which are shared across tests */
   override val resource: Resource[IO, (Region, LocalStackContainer, Sink[IO])] =

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceSpec.scala
@@ -21,18 +21,26 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 
 import com.snowplowanalytics.snowplow.sources.EventProcessingConfig
 import com.snowplowanalytics.snowplow.sources.EventProcessingConfig.NoWindowing
+import com.snowplowanalytics.snowplow.it.DockerPull
 import com.snowplowanalytics.snowplow.it.kinesis._
 
 import java.time.Instant
 
 import Utils._
 
+import org.specs2.specification.BeforeAll
+
 class KinesisSourceSpec
     extends CatsResource[IO, (LocalStackContainer, KinesisAsyncClient, String => KinesisSourceConfig)]
-    with SpecificationLike {
+    with SpecificationLike
+    with BeforeAll {
   import KinesisSourceSpec._
 
   override val Timeout: FiniteDuration = 3.minutes
+  override def beforeAll(): Unit = {
+    DockerPull.pull(Localstack.image, Localstack.tag)
+    super.beforeAll()
+  }
 
   /** Resources which are shared across tests */
   override val resource: Resource[IO, (LocalStackContainer, KinesisAsyncClient, String => KinesisSourceConfig)] =

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Localstack.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Localstack.scala
@@ -16,14 +16,15 @@ import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.regions.Region
 
 object Localstack {
-
+  val image = "localstack/localstack"
+  val tag   = "2.3.2"
   def resource(
     region: Region,
     kinesisInitializeStreams: String,
     loggerName: String
   ): Resource[IO, LocalStackContainer] =
     Resource.make {
-      val localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.3.2"))
+      val localstack = new LocalStackContainer(DockerImageName.parse(s"$image:$tag"))
       localstack.addEnv("AWS_DEFAULT_REGION", region.id)
       localstack.addEnv("KINESIS_INITIALIZE_STREAMS", kinesisInitializeStreams)
       localstack.addExposedPort(4566)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,6 +52,7 @@ object Dependencies {
     val catsEffectSpecs2 = "1.5.0"
     val localstack       = "1.19.0"
     val eventGen         = "0.7.0"
+    val dockerJava       = "3.3.6"
   }
 
   val catsEffectKernel  = "org.typelevel"          %% "cats-effect-kernel"      % V.catsEffect
@@ -110,6 +111,7 @@ object Dependencies {
   val catsEffectTestkit = "org.typelevel"         %% "cats-effect-testkit"           % V.catsEffect       % Test
   val catsEffectSpecs2  = "org.typelevel"         %% "cats-effect-testing-specs2"    % V.catsEffectSpecs2 % Test
   val eventGen          = "com.snowplowanalytics" %% "snowplow-event-generator-core" % V.eventGen         % Test
+  val dockerJava        = "com.github.docker-java" % "docker-java"                   % V.dockerJava
 
   val streamsDependencies = Seq(
     cats,
@@ -146,7 +148,8 @@ object Dependencies {
     catsEffectSpecs2It  % Test,
     catsRetry           % Test,
     localstackIt        % Test,
-    slf4jIt             % Test
+    slf4jIt             % Test,
+    dockerJava          % Test
   )
 
   val kafkaDependencies = Seq(


### PR DESCRIPTION
Previously, we relied on org.testcontainers' method of fetching container image for StatsD. This was counted towards test timeout and rarely actually triggered the tests.
Now, the image is fetched as part of beforeAll step and handled as part of setup time that's not counted towards the timeout. If the image is already available the cost of blocking is nearly zero.

testcontainers/ryuk is a resource reaper used for cleaning things up after tests complete. In CI we only run tests once after which the VM is shut down. Ryuk fetching happens while creating a `CatsResource` that is counted towards timeout. This can take a long time in CI and rarely happens at dev time.
Therefore, for CI ryuk is now disabled.