### PR TITLE
Kinesis source options to allow less lease-stealing

### DIFF
--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.time.Instant
 import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.DurationLong
 
 import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest
 
@@ -90,12 +91,14 @@ object Utils {
   def getKinesisSourceConfig(endpoint: URI)(streamName: String): KinesisSourceConfig = KinesisSourceConfig(
     UUID.randomUUID().toString,
     streamName,
+    UUID.randomUUID.toString,
     KinesisSourceConfig.InitialPosition.TrimHorizon,
     KinesisSourceConfig.Retrieval.Polling(1),
     PosInt.unsafeFrom(1),
     Some(endpoint),
     Some(endpoint),
-    Some(endpoint)
+    Some(endpoint),
+    10.seconds
   )
 
   def getKinesisSinkConfig(endpoint: URI)(streamName: String): KinesisSinkConfig = KinesisSinkConfig(

--- a/modules/kinesis/src/main/resources/reference.conf
+++ b/modules/kinesis/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 snowplow.defaults: {
   sources: {
     kinesis: {
+      workerIdentifier: ${?HOSTNAME}
       initialPosition: {
         type: "LATEST"
       }
@@ -9,6 +10,7 @@ snowplow.defaults: {
         maxRecords: 1000
       }
       bufferSize: 1
+      leaseDuration: "10 seconds"
     }
   }
 

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceConfig.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceConfig.scala
@@ -10,21 +10,25 @@ package com.snowplowanalytics.snowplow.sources.kinesis
 import eu.timepit.refined.types.all.PosInt
 
 import io.circe._
+import io.circe.config.syntax._
 import io.circe.generic.extras.semiauto.deriveConfiguredDecoder
 import io.circe.generic.extras.Configuration
 
 import java.net.URI
 import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 
 case class KinesisSourceConfig(
   appName: String,
   streamName: String,
+  workerIdentifier: String,
   initialPosition: KinesisSourceConfig.InitialPosition,
   retrievalMode: KinesisSourceConfig.Retrieval,
   bufferSize: PosInt,
   customEndpoint: Option[URI],
   dynamodbCustomEndpoint: Option[URI],
-  cloudwatchCustomEndpoint: Option[URI]
+  cloudwatchCustomEndpoint: Option[URI],
+  leaseDuration: FiniteDuration
 )
 
 object KinesisSourceConfig {

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceConfigSpec.scala
@@ -14,6 +14,7 @@ import io.circe.config.syntax.CirceConfigOps
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import org.specs2.Specification
+import scala.concurrent.duration.DurationLong
 
 class KinesisSourceConfigSpec extends Specification {
   import KinesisSourceConfigSpec._
@@ -31,6 +32,7 @@ class KinesisSourceConfigSpec extends Specification {
     {
       "appName": "my-app",
       "streamName": "my-stream",
+      "workerIdentifier": "my-identifier",
       "retrievalMode": {
         "type": "Polling",
         "maxRecords": 42
@@ -38,7 +40,8 @@ class KinesisSourceConfigSpec extends Specification {
       "initialPosition": {
         "type": "TrimHorizon"
       },
-      "bufferSize": 42
+      "bufferSize": 42,
+      "leaseDuration": "20 seconds"
     }
     """
 
@@ -46,9 +49,11 @@ class KinesisSourceConfigSpec extends Specification {
       List(
         c.appName must beEqualTo("my-app"),
         c.streamName must beEqualTo("my-stream"),
+        c.workerIdentifier must beEqualTo("my-identifier"),
         c.initialPosition must beEqualTo(KinesisSourceConfig.InitialPosition.TrimHorizon),
         c.retrievalMode must beEqualTo(KinesisSourceConfig.Retrieval.Polling(42)),
-        c.bufferSize.value must beEqualTo(42)
+        c.bufferSize.value must beEqualTo(42),
+        c.leaseDuration must beEqualTo(20.seconds)
       ).reduce(_ and _)
     }
   }
@@ -58,6 +63,7 @@ class KinesisSourceConfigSpec extends Specification {
     {
       "appName": "my-app",
       "streamName": "my-stream",
+      "workerIdentifier": "my-identifier",
       "retrievalMode": {
         "type": "POLLING",
         "maxRecords": 42
@@ -65,7 +71,8 @@ class KinesisSourceConfigSpec extends Specification {
       "initialPosition": {
         "type": "TRIM_HORIZON"
       },
-      "bufferSize": 42
+      "bufferSize": 42,
+      "leaseDuration": "20 seconds"
     }
     """
 
@@ -73,9 +80,11 @@ class KinesisSourceConfigSpec extends Specification {
       List(
         c.appName must beEqualTo("my-app"),
         c.streamName must beEqualTo("my-stream"),
+        c.workerIdentifier must beEqualTo("my-identifier"),
         c.initialPosition must beEqualTo(KinesisSourceConfig.InitialPosition.TrimHorizon),
         c.retrievalMode must beEqualTo(KinesisSourceConfig.Retrieval.Polling(42)),
-        c.bufferSize.value must beEqualTo(42)
+        c.bufferSize.value must beEqualTo(42),
+        c.leaseDuration must beEqualTo(20.seconds)
       ).reduce(_ and _)
     }
   }
@@ -96,12 +105,14 @@ class KinesisSourceConfigSpec extends Specification {
     val expected = KinesisSourceConfig(
       appName                  = "my-app",
       streamName               = "my-stream",
+      workerIdentifier         = System.getenv("HOSTNAME"),
       initialPosition          = KinesisSourceConfig.InitialPosition.Latest,
       retrievalMode            = KinesisSourceConfig.Retrieval.Polling(1000),
       bufferSize               = PosInt.unsafeFrom(1),
       customEndpoint           = None,
       dynamodbCustomEndpoint   = None,
-      cloudwatchCustomEndpoint = None
+      cloudwatchCustomEndpoint = None,
+      leaseDuration            = 10.seconds
     )
 
     result.as[Wrapper] must beRight.like { case w: Wrapper =>

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -42,7 +42,10 @@ object BuildSettings {
     scalacOptions += "-Ywarn-macros:after",
     scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
     Test / fork := true,
-    Test / envVars := Map("CONFIG_PARSER_TEST_ENV" -> "envValue"),
+    Test / envVars := Map(
+      "CONFIG_PARSER_TEST_ENV" -> "envValue",
+      "HOSTNAME" -> sys.env.getOrElse("HOSTNAME", "fallback-hostname") // Tests require HOSTNAME to be set
+    ),
     addCompilerPlugin(Dependencies.betterMonadicFor),
     addCompilerPlugin(Dependencies.kindProjector),
     ThisBuild / autoAPIMappings := true,


### PR DESCRIPTION
Our snowplow stream-processing apps tend to produce duplicates on AWS. It happens because KCL allows workers to "steal" shard leases from other workers.

By adjusting some KCL configuration params, we can minimize lease stealing under some circumstances:

- `workerIdentifier`: If a pod uses a consistent name, then whenever the pod restarts (e.g. after crashing or after a rollout) then the pod can re-claim leases that it previously owned before the restart
- `leaseDuration`: The KCL default is 10 seconds.  If we increase this, then we can allow a pod longer to re-claim its old leases after a restart.