### PR TITLE
Eagerness of windows should be configurable

### DIFF
--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/EventProcessingConfig.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/EventProcessingConfig.scala
@@ -43,15 +43,23 @@ object EventProcessingConfig {
    *   several parallel instances of the app all start at the same time. All instances in the group
    *   should end windows at slightly different times, so that downstream gets a more steady flow of
    *   completed batches.
+   * @param numEagerWindows
+   *   Controls how many windows are allowed to start eagerly ahead of an earlier window that is
+   *   still being finalized. For example, if numEagerWindows=2 then window 42 is allowed to start
+   *   while windows 40 and 41 are still finalizing.
    */
-  case class TimedWindows(duration: FiniteDuration, firstWindowScaling: Double) extends Windowing
+  case class TimedWindows(
+    duration: FiniteDuration,
+    firstWindowScaling: Double,
+    numEagerWindows: Int
+  ) extends Windowing
 
   object TimedWindows {
-    def build[F[_]: Sync](duration: FiniteDuration): F[TimedWindows] =
+    def build[F[_]: Sync](duration: FiniteDuration, numEagerWindows: Int): F[TimedWindows] =
       for {
         random <- Random.scalaUtilRandom
         factor <- random.nextDouble
-      } yield TimedWindows(duration, factor)
+      } yield TimedWindows(duration, factor, numEagerWindows)
   }
 
 }


### PR DESCRIPTION
common-streams has a feature in which a timed window of events is allowed to start processing before the previous window has finalized. This is a great feature for making full use of available cpu. It means are are always working the cpu hard, even if some slow I/O is required to finalize the window.

Until now, the eagerness only stretched to consecutive windows. E.g. If window 1 is still finalizing then it is allowed for window 2 to start processing; but it is not allowed for window 3 to start processing.

For Lake Loader I found it is better to let the eagerness stretch further.  E.g. window 3 is allowed to start processing even if windows 1 and 2 are both still finalizing.

This PR makes configurable how many windows may start eagerly ahead of a finalzing window.