### PR TITLE
Kinesis source must report its latency when KCL is not healthy

### DIFF
--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sources/kafka/KafkaSource.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sources/kafka/KafkaSource.scala
@@ -20,6 +20,7 @@ import scala.reflect._
 
 import java.nio.ByteBuffer
 import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 
 // kafka
 import fs2.kafka._
@@ -49,6 +50,9 @@ object KafkaSource {
 
       def stream: Stream[F, Stream[F, LowLevelEvents[KafkaCheckpoints[F]]]] =
         kafkaStream(config, authHandlerClass)
+
+      def lastLiveness: F[FiniteDuration] =
+        Sync[F].realTime
     }
 
   case class OffsetAndCommit[F[_]](offset: Long, commit: F[Unit])

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSource.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSource.scala
@@ -61,6 +61,9 @@ object PubsubSource {
 
       def stream: Stream[F, Stream[F, LowLevelEvents[Chunk[AckReplyConsumer]]]] =
         pubsubStream(config)
+
+      def lastLiveness: F[FiniteDuration] =
+        Sync[F].realTime
     }
 
   private def pubsubCheckpointer[F[_]: Async]: PubSubCheckpointer[F] = new PubSubCheckpointer[F] {

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
@@ -73,8 +73,17 @@ object SourceAndAck {
    */
   case class LaggingEventProcessor(latency: FiniteDuration) extends Unhealthy
 
+  /**
+   * The health status expected if the source of events has been inactive for some time
+   *
+   * @param duration
+   *   How long the source of events has been inactive
+   */
+  case class InactiveSource(duration: FiniteDuration) extends Unhealthy
+
   implicit def showUnhealthy: Show[Unhealthy] = Show {
     case Disconnected                   => "No connection to a source of events"
     case LaggingEventProcessor(latency) => show"Processing latency is $latency"
+    case InactiveSource(duration)       => show"Source of events has been inactive for $duration"
   }
 }


### PR DESCRIPTION
Part of PDP-1196

The KCL is sadly not very good at crashing and exiting. If the underlying Kinesis client has errors (e.g. permissions errors) then KCL tends to stay alive and not propagate the exceptions to our application code. We want the app to crash under these circumstances because that triggers an alert.    
    
common-streams already has a health check feature, in which a health probe becomes unhealthy if a single event gets stuck without making progress.    
    
This PR leans on the existing health check feature, so it also becomes unhealthy if the Kinesis client is not regularly receiving healthy responses.    
    
I configured KCL to invoke our record processor every time it polls for records, even if the batch is empty. This means the health check still works even if there are no events in the stream.