### PR TITLE
PubSub source scale the parallel pull count with number of cores

### DIFF
--- a/modules/pubsub/src/main/resources/reference.conf
+++ b/modules/pubsub/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 snowplow.defaults: {
   sources: {
     pubsub: {
-      parallelPullCount: 1
+      parallelPullFactor: 0.5
       bufferMaxBytes: 10000000
       maxAckExtensionPeriod: "1 hour"
       minDurationPerAckExtension: "60 seconds"

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
@@ -17,7 +17,7 @@ import com.snowplowanalytics.snowplow.pubsub.GcpUserAgent
 
 case class PubsubSourceConfig(
   subscription: PubsubSourceConfig.Subscription,
-  parallelPullCount: Int,
+  parallelPullFactor: BigDecimal,
   bufferMaxBytes: Int,
   maxAckExtensionPeriod: FiniteDuration,
   minDurationPerAckExtension: FiniteDuration,

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
@@ -42,7 +42,7 @@ class PubsubSourceConfigSpec extends Specification {
 
     val expected = PubsubSourceConfig(
       subscription               = PubsubSourceConfig.Subscription("my-project", "my-subscription"),
-      parallelPullCount          = 1,
+      parallelPullFactor         = BigDecimal(0.5),
       bufferMaxBytes             = 10000000,
       maxAckExtensionPeriod      = 1.hour,
       minDurationPerAckExtension = 1.minute,


### PR DESCRIPTION
The PubSub Source parameter `parallelPullCount` was used to set the parallelism of the underlying Subscriber. With a higher pull count, the Subscriber can supply events more quickly to the downstream of the application, but there is more overhead.

For typical Snowplow apps, a pull count of 1 is sufficient on small instances. But when there is more cpu availalbe, the downstream app processes events more quickly, and therefore we need a higher pull count to provide the events.

This PR makes it so pull count is picked dynamically based on available cpu. Snowplow apps on bigger instances will automatically get the benefit of this change, without requiring the user to explicitly set the pull count.