### PR TITLE
Fix randomly adjusted first window size

### DIFF
--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
@@ -272,7 +272,9 @@ private[sources] object LowLevelSource {
           val pull = for {
             _ <- Pull.eval(Logger[F].info(s"Opening first window with randomly adjusted duration of $timeout"))
             _ <- timedPull.timeout(timeout)
-          } yield go(timedPull, None)
+            q <- Pull.eval(Queue.synchronous[F, Option[A]])
+            _ <- Pull.output1(Stream.fromQueueNoneTerminated(q))
+          } yield go(timedPull, Some(q))
           pull.flatten
         }
         .stream


### PR DESCRIPTION
common-streams has a feature where the first window is randomly adjusted to a different size. This helps in a deployment where a large number of pods might all start at the same time, but we pods to have mutually staggered windows, e.g. to avoid write conflicts in the lake loader.

Unfortunately I broke the feature in #64 so this fixes it again.

I also add a test so it won't get broken again.