### PR TITLE
Webhook for sending alert messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val runtimeCommon: Project = project
   .settings(BuildSettings.publishSettings)
   .settings(BuildSettings.mimaSettings)
   .settings(BuildSettings.docsSettings)
+  .settings(BuildSettings.igluTestSettings)
   .settings(
     previewFixedPort := Some(9994),
     Preprocess / preprocessVars := Map("VERSION" -> version.value)

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Webhook.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Webhook.scala
@@ -25,7 +25,6 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import com.snowplowanalytics.iglu.core.circe.implicits._
 import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
-import com.snowplowanalytics.snowplow.runtime.AppInfo
 
 trait Webhook[F[_], Alert] {
   def alert(message: Alert): F[Unit]

--- a/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Webhook.scala
+++ b/modules/runtime-common/src/main/scala/com/snowplowanalytics/snowplow/runtime/Webhook.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This software is made available by Snowplow Analytics, Ltd.,
+ * under the terms of the Snowplow Limited Use License Agreement, Version 1.0
+ * located at https://docs.snowplow.io/limited-use-license-1.0
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY PORTION
+ * OF THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.
+ */
+
+package com.snowplowanalytics.snowplow.runtime
+
+import cats.effect.{Async, Sync}
+import cats.implicits._
+import cats.Show
+import io.circe.{Decoder, Json}
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import org.http4s.circe.jsonEncoder
+import org.http4s.client.Client
+import org.http4s.{Method, Request}
+import org.http4s.{ParseFailure, Uri}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import com.snowplowanalytics.iglu.core.circe.implicits._
+import com.snowplowanalytics.iglu.core.{SchemaKey, SchemaVer, SelfDescribingData}
+import com.snowplowanalytics.snowplow.runtime.AppInfo
+
+trait Webhook[F[_], Alert] {
+  def alert(message: Alert): F[Unit]
+}
+
+object Webhook {
+
+  final case class Config(endpoint: Uri, tags: Map[String, String])
+
+  object Config {
+    implicit def webhookConfigDecoder: Decoder[Config] = {
+      implicit val http4sUriDecoder: Decoder[Uri] =
+        Decoder[String].emap(s => Either.catchOnly[ParseFailure](Uri.unsafeFromString(s)).leftMap(_.toString))
+      deriveDecoder[Config]
+    }
+  }
+
+  private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
+
+  def create[F[_]: Async, Alert: Show](
+    config: Option[Config],
+    appInfo: AppInfo,
+    httpClient: Client[F]
+  ): Webhook[F, Alert] = new Webhook[F, Alert] {
+
+    override def alert(message: Alert): F[Unit] =
+      config match {
+        case Some(webhookConfig) =>
+          val request = buildHttpRequest[F, Alert](webhookConfig, appInfo, message)
+          Logger[F].info(show"Sending alert to ${webhookConfig.endpoint} with details of the setup error...") *>
+            executeHttpRequest[F](webhookConfig, httpClient, request)
+        case None =>
+          Logger[F].debug(s"Webhook monitoring is not configured, skipping alert: $message")
+      }
+  }
+
+  private def buildHttpRequest[F[_], Alert: Show](
+    webhookConfig: Config,
+    appInfo: AppInfo,
+    alert: Alert
+  ): Request[F] =
+    Request[F](Method.POST, webhookConfig.endpoint)
+      .withEntity(toSelfDescribingJson(alert, appInfo, webhookConfig.tags))
+
+  private def executeHttpRequest[F[_]: Async](
+    webhookConfig: Config,
+    httpClient: Client[F],
+    request: Request[F]
+  ): F[Unit] =
+    httpClient
+      .run(request)
+      .use { response =>
+        if (response.status.isSuccess) Sync[F].unit
+        else {
+          response
+            .as[String]
+            .flatMap(body => Logger[F].error(show"Webhook ${webhookConfig.endpoint} returned non-2xx response:\n$body"))
+        }
+      }
+      .handleErrorWith { e =>
+        Logger[F].error(e)(show"Webhook ${webhookConfig.endpoint} resulted in exception without a response")
+      }
+
+  /** Restrict the length of an alert message to be compliant with alert iglu schema */
+  private val MaxAlertPayloadLength = 4096
+
+  private def toSelfDescribingJson[Alert: Show](
+    alert: Alert,
+    appInfo: AppInfo,
+    tags: Map[String, String]
+  ): Json =
+    SelfDescribingData(
+      schema = SchemaKey("com.snowplowanalytics.monitoring.loader", "alert", "jsonschema", SchemaVer.Full(1, 0, 0)),
+      data = Json.obj(
+        "appName" -> appInfo.name.asJson,
+        "appVersion" -> appInfo.version.asJson,
+        "message" -> alert.show.take(MaxAlertPayloadLength).asJson,
+        "tags" -> tags.asJson
+      )
+    ).normalize
+
+}

--- a/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/WebhookSpec.scala
+++ b/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/WebhookSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.runtime
+
+import cats.{Applicative, Id, Show}
+import cats.implicits._
+import cats.effect.testing.specs2.CatsEffect
+import cats.effect.{Clock, IO, Ref, Resource}
+import org.http4s.{Headers, Method, Response}
+import org.http4s.client.Client
+import io.circe.Json
+import io.circe.literal.JsonStringContext
+import io.circe.parser.{parse => circeParse}
+import io.circe.DecodingFailure
+import org.http4s.Uri
+import org.specs2.Specification
+
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+import com.snowplowanalytics.iglu.core.SelfDescribingData
+import com.snowplowanalytics.iglu.core.circe.implicits._
+import com.snowplowanalytics.iglu.client.IgluCirceClient
+import com.snowplowanalytics.iglu.client.resolver.Resolver
+import com.snowplowanalytics.iglu.client.resolver.registries.JavaNetRegistryLookup.idLookupInstance
+
+class WebhookSpec extends Specification with CatsEffect {
+  import WebhookSpec._
+
+  def is = s2"""
+  The webhook config decoder should:
+    Decode a valid JSON config $decode1
+    Not decode JSON if a required field is missing $decode2
+  The webhook should:
+    Not send any payloads if config is empty $send1
+    Send a valid payload if given valid config $send2
+    Ignore any exception raised by sending webhook $send3
+  """
+
+  def decode1 = {
+    val json = json"""
+    {
+      "endpoint": "http://example.com/xyz?abc=123",
+      "tags": {
+        "abc": "xyz"
+      }
+    }
+    """
+
+    json.as[Option[Webhook.Config]] must beRight.like { case Some(c: Webhook.Config) =>
+      List(
+        c.endpoint must beEqualTo(Uri.unsafeFromString("http://example.com/xyz?abc=123")),
+        c.tags must beEqualTo(Map("abc" -> "xyz"))
+      ).reduce(_ and _)
+    }
+  }
+
+  def decode2 = {
+    val json = json"""
+    {
+      "tags": {
+        "abc": "xyz"
+      }
+    }
+    """
+
+    json.as[Option[Webhook.Config]] must beLeft.like { case e: DecodingFailure =>
+      e.show must beEqualTo("DecodingFailure at .endpoint: Missing required field")
+    }
+  }
+
+  def send1 = for {
+    ref <- Ref[IO].of(List.empty[ReportedRequest])
+    httpClient = reportingHttpClient(ref)
+    webhook    = Webhook.create[IO, TestAlert](None, testAppInfo, httpClient)
+    _ <- webhook.alert(TestAlert("this is a test"))
+    results <- ref.get
+  } yield results must beEmpty
+
+  def send2 = for {
+    ref <- Ref[IO].of(List.empty[ReportedRequest])
+    httpClient = reportingHttpClient(ref)
+    webhook    = Webhook.create[IO, TestAlert](Some(testConfig), testAppInfo, httpClient)
+    _ <- webhook.alert(TestAlert("this is a test"))
+    results <- ref.get
+  } yield List(
+    results must haveSize(1),
+    results must contain { req: ReportedRequest =>
+      List(
+        mustHaveValidAlertBody(req.body),
+        req.method must beEqualTo(Method.POST),
+        req.uri must beEqualTo(testConfig.endpoint),
+        req.headers.toString must contain("Content-Type: application/json")
+      ).reduce(_ and _)
+    }
+  ).reduce(_ and _)
+
+  def send3 = {
+    val webhook = Webhook.create[IO, TestAlert](Some(testConfig), testAppInfo, errorRaisingHttpClient)
+    for {
+      _ <- webhook.alert(TestAlert("this is a test"))
+    } yield ok
+  }
+
+  private def mustHaveValidAlertBody(body: String) =
+    circeParse(body) must beRight.like { case json: Json =>
+      json.as[SelfDescribingData[Json]] must beRight.like { case sdj: SelfDescribingData[Json] =>
+        List(
+          sdj.schema.toSchemaUri must beEqualTo("iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0"),
+          igluCirceClient.check(sdj).value must beRight
+        ).reduce(_ and _)
+      }
+    }
+
+}
+
+object WebhookSpec {
+
+  case class TestAlert(msg: String)
+
+  implicit def testAlertShow: Show[TestAlert] =
+    Show(_.msg)
+
+  val testAppInfo: AppInfo = new AppInfo {
+    def name: String        = "testName"
+    def version: String     = "testVersion"
+    def dockerAlias: String = "testDockerAlias"
+    def cloud: String       = "testCloud"
+  }
+
+  def testConfig: Webhook.Config = Webhook.Config(
+    endpoint = Uri.unsafeFromString("http://example.com/xyz?abc=123"),
+    tags     = Map("myTag" -> "myValue")
+  )
+
+  // Used in tests to report the request that was sent to the webhook
+  case class ReportedRequest(
+    method: Method,
+    uri: Uri,
+    headers: Headers,
+    body: String
+  )
+
+  // A http4s Client that reports what requests it has sent
+  def reportingHttpClient(ref: Ref[IO, List[ReportedRequest]]): Client[IO] =
+    Client[IO] { request =>
+      Resource.eval {
+        for {
+          body <- request.bodyText.compile.string
+          _ <- ref.update(_ :+ ReportedRequest(request.method, request.uri, request.headers, body))
+        } yield Response.notFound[IO]
+      }
+    }
+
+  // A http4s Client that raises exceptions
+  def errorRaisingHttpClient: Client[IO] =
+    Client[IO] { _ =>
+      Resource.raiseError[IO, Response[IO], Throwable](new RuntimeException("boom!"))
+    }
+
+  def igluCirceClient: IgluCirceClient[Id] =
+    IgluCirceClient.fromResolver[Id](Resolver[Id](Nil, None), 0)
+
+  // Needed because we use Id effect in tests for iglu-scala-client
+  implicit val catsClockIdInstance: Clock[Id] = new Clock[Id] {
+    override def applicative: Applicative[Id] = Applicative[Id]
+
+    override def monotonic: Id[FiniteDuration] = FiniteDuration(System.nanoTime(), TimeUnit.NANOSECONDS)
+
+    override def realTime: Id[FiniteDuration] = FiniteDuration(System.currentTimeMillis(), TimeUnit.MILLISECONDS)
+  }
+}

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -115,7 +115,8 @@ object BuildSettings {
     Test / igluUris := Seq(
       // Iglu Central schemas used in tests will get pre-fetched by sbt
       "iglu:com.snowplowanalytics.iglu/anything-a/jsonschema/1-0-0",
-      "iglu:com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0"
+      "iglu:com.snowplowanalytics.snowplow.media/ad_break_end_event/jsonschema/1-0-0",
+      "iglu:com.snowplowanalytics.monitoring.loader/alert/jsonschema/1-0-0"
     )
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,6 +58,7 @@ object Dependencies {
   val log4cats          = "org.typelevel"          %% "log4cats-slf4j"          % V.log4cats
   val catsRetry         = "com.github.cb372"       %% "cats-retry"              % V.catsRetry
   val emberServer       = "org.http4s"             %% "http4s-ember-server"     % V.http4s
+  val http4sCirce       = "org.http4s"             %% "http4s-circe"            % V.http4s
   val decline           = "com.monovore"           %% "decline-effect"          % V.decline
   val circeConfig       = "io.circe"               %% "circe-config"            % V.circeConfig
   val circeGeneric      = "io.circe"               %% "circe-generic"           % V.circe
@@ -169,6 +170,7 @@ object Dependencies {
     circeGeneric,
     emberServer,
     fs2,
+    http4sCirce,
     igluClient,
     log4cats,
     slf4jApi,


### PR DESCRIPTION
Several of our newer Snowplow apps send alert messages to a webhook. They all share a common configuration and implementation.  But currently the implementation is duplicated across each app.  This PR consolidates it into one place.