### PR TITLE
Pubsub source open more transport channels

### DIFF
--- a/modules/pubsub/src/main/resources/reference.conf
+++ b/modules/pubsub/src/main/resources/reference.conf
@@ -10,6 +10,7 @@ snowplow.defaults: {
         productName: "Snowplow OSS"
       }
       shutdownTimeout: "30 seconds"
+      maxPullsPerTransportChannel: 16
     }
   }
 

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
@@ -23,7 +23,8 @@ case class PubsubSourceConfig(
   minDurationPerAckExtension: FiniteDuration,
   maxDurationPerAckExtension: FiniteDuration,
   gcpUserAgent: GcpUserAgent,
-  shutdownTimeout: FiniteDuration
+  shutdownTimeout: FiniteDuration,
+  maxPullsPerTransportChannel: Int
 )
 
 object PubsubSourceConfig {

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
@@ -41,14 +41,15 @@ class PubsubSourceConfigSpec extends Specification {
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
     val expected = PubsubSourceConfig(
-      subscription               = PubsubSourceConfig.Subscription("my-project", "my-subscription"),
-      parallelPullFactor         = BigDecimal(0.5),
-      bufferMaxBytes             = 10000000,
-      maxAckExtensionPeriod      = 1.hour,
-      minDurationPerAckExtension = 1.minute,
-      maxDurationPerAckExtension = 10.minutes,
-      gcpUserAgent               = GcpUserAgent("Snowplow OSS", "example-version"),
-      shutdownTimeout            = 30.seconds
+      subscription                = PubsubSourceConfig.Subscription("my-project", "my-subscription"),
+      parallelPullFactor          = BigDecimal(0.5),
+      bufferMaxBytes              = 10000000,
+      maxAckExtensionPeriod       = 1.hour,
+      minDurationPerAckExtension  = 1.minute,
+      maxDurationPerAckExtension  = 10.minutes,
+      gcpUserAgent                = GcpUserAgent("Snowplow OSS", "example-version"),
+      shutdownTimeout             = 30.seconds,
+      maxPullsPerTransportChannel = 16
     )
 
     result.as[Wrapper] must beRight.like { case w: Wrapper =>


### PR DESCRIPTION
Previously the pubsub SDK opened just a single transport channel (roughly equivalent to a TCP channel).

Some snowplow apps we need to batch up a very large number of events from the source before acking.  In those circumstances it is good to open more streaming pulls (a type of RPC) to keep the pubsub subscription healthy.  But to open more streaming pulls we also need to open more transport channels (TCP channels) to support all the RPCs.

This commit adds a new config parameter `maxPullsPerTransportChannel`. The default value 16 is good for most apps.