### PR TITLE
Change default webhook heartbeat period to 5 minutes

### DIFF
--- a/modules/runtime-common/src/main/resources/reference.conf
+++ b/modules/runtime-common/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ snowplow.defaults: {
 
   webhook: {
     tags: {}
-    heartbeat: "60 minutes"
+    heartbeat: "5 minutes"
   }
 
   telemetry: {

--- a/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/WebhookConfigSpec.scala
+++ b/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/WebhookConfigSpec.scala
@@ -103,7 +103,7 @@ class WebhookConfigSpec extends Specification {
     val expected = Webhook.Config(
       endpoint  = Some(Uri.unsafeFromString("http://example.com/xyz?abc=123")),
       tags      = Map.empty,
-      heartbeat = 60.minutes
+      heartbeat = 5.minutes
     )
 
     result.as[ConfigWrapper] must beRight { (w: ConfigWrapper) =>


### PR DESCRIPTION
...as requested by the downstream consumers of this webhook