### PR TITLE
Fix TypedTabledEntity build

### DIFF
--- a/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/TypedTabledEntity.scala
+++ b/modules/loaders-common/src/main/scala/com/snowplowanalytics/snowplow/loaders/transform/TypedTabledEntity.scala
@@ -58,8 +58,11 @@ object TypedTabledEntity {
     subVersions: Set[SchemaSubVersion],
     schemas: NonEmptyList[SelfDescribingSchema[Schema]]
   ): Option[TypedTabledEntity] =
-    schemas
-      .traverse(sds => fieldFromSchema(tabledEntity, sds.schema).map((_, sds)))
+    schemas.toList
+      .flatMap { sds =>
+        fieldFromSchema(tabledEntity, sds.schema).map((_, sds))
+      }
+      .toNel
       .map { nel =>
         val (rootField, rootSchema) = nel.head
         val tte                     = TypedTabledEntity(tabledEntity, rootField, Set(keyToSubVersion(rootSchema.self.schemaKey)), Nil)

--- a/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/test_empty_prop/jsonschema/1-0-0
+++ b/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/test_empty_prop/jsonschema/1-0-0
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+        "vendor": "myvendor",
+        "name": "test_empty_prop",
+        "format": "jsonschema",
+        "version": "1-0-0"
+    },
+    "properties": {},
+    "additionalProperties": false,
+    "type": "object"
+}

--- a/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/test_empty_prop/jsonschema/1-0-1
+++ b/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/test_empty_prop/jsonschema/1-0-1
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+    "self": {
+        "vendor": "myvendor",
+        "name": "test_empty_prop",
+        "format": "jsonschema",
+        "version": "1-0-1"
+    },
+    "properties": {
+      "myString": {"type": "string"}
+    },
+    "additionalProperties": false,
+    "type": "object"
+}


### PR DESCRIPTION
This PR fixes a bug introduced after `0.8.0-M2`. See the snippet below for a simpler visualization.

```scala
scala> import cats.data.NonEmptyList
import cats.data.NonEmptyList

scala> import cats.syntax.all._
import cats.syntax.all._

scala> def parseInt(s: String): Option[Int] = Either.catchOnly[NumberFormatException](s.toInt).toOption
def parseInt(s: String): Option[Int]

scala> NonEmptyList.of("1", "2", "3").traverse(parseInt)
val res0: Option[cats.data.NonEmptyList[Int]] = Some(NonEmptyList(1, 2, 3))

scala> NonEmptyList.of("1", "two", "3").traverse(parseInt)
val res1: Option[cats.data.NonEmptyList[Int]] = None

scala> NonEmptyList.of("1", "two", "3").toList.flatMap(parseInt).toNel
val res2: Option[cats.data.NonEmptyList[Int]] = Some(NonEmptyList(1, 3))
```