### PR TITLE
Fix for `_schema_version` overriding non-object entity data

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Dependencies {
     val badrows      = "2.3.0"
     val igluClient   = "4.0.0"
     val tracker      = "2.0.0"
-    val analyticsSdk = "3.2.1"
+    val analyticsSdk = "3.2.2"
 
     // tests
     val specs2           = "4.20.0"


### PR DESCRIPTION
We recommend that Snowplow entities should be JSON *objects* only. But technically it is possible for them to be something else, e.g. a JSON array.

Before this fix, we accidentally erased the original value if a context was not a JSON object. The bug only affected unstructed destinations, e.g. the Snowflake loader.

The fix was implented in snowplow/snowplow-scala-analytics-sdk#137 and is imported here.