### PR TITLE
Preserve original field order when merging schemas

### DIFF
--- a/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/10-0-0
+++ b/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/10-0-0
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "10-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "col_m": {"type": "string"},
+    "col_n": {"type": "string"}
+  }
+}

--- a/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/10-0-1
+++ b/modules/loaders-common/src/test/resources/iglu-client-embedded/schemas/myvendor/myschema/jsonschema/10-0-1
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "self": {
+    "vendor": "myvendor",
+    "name": "myschema",
+    "format": "jsonschema",
+    "version": "10-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "col_a": {"type": "string"},
+    "col_m": {"type": "string"},
+    "col_z": {"type": "string"}
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
     val azureSdk = "1.11.4"
 
     // Snowplow
-    val schemaDdl    = "0.25.0"
+    val schemaDdl    = "0.26.0"
     val badrows      = "2.3.0"
     val igluClient   = "4.0.0"
     val tracker      = "2.0.0"


### PR DESCRIPTION
See snowplow/schema-ddl#213

When a schema is evolved (e.g. from `1-0-0` to `1-0-1`) we create a merged struct column combining fields from new and old schema.

For some loaders it is important that newly-added nested fields come after the original fields. E.g. Lake Loader with Hudi and Glue sync enabled.