### PR TITLE
PubSub Source using Unary Pull

### DIFF
--- a/modules/pubsub/src/main/resources/reference.conf
+++ b/modules/pubsub/src/main/resources/reference.conf
@@ -2,15 +2,13 @@ snowplow.defaults: {
   sources: {
     pubsub: {
       parallelPullFactor: 0.5
-      bufferMaxBytes: 10000000
-      maxAckExtensionPeriod: "1 hour"
-      minDurationPerAckExtension: "60 seconds"
-      maxDurationPerAckExtension: "600 seconds"
+      durationPerAckExtension: "60 seconds"
+      minRemainingAckDeadline: 0.1
+      maxMessagesPerPull: 1000
+      debounceRequests: "100 millis"
       gcpUserAgent: {
         productName: "Snowplow OSS"
       }
-      shutdownTimeout: "30 seconds"
-      maxPullsPerTransportChannel: 16
     }
   }
 

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/pubsub/FutureInterop.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/pubsub/FutureInterop.scala
@@ -13,7 +13,7 @@ import com.google.api.core.{ApiFuture, ApiFutureCallback, ApiFutures}
 import com.google.common.util.concurrent.MoreExecutors
 
 object FutureInterop {
-  def fromFuture[F[_]: Async, A](fut: ApiFuture[A]): F[Unit] =
+  def fromFuture[F[_]: Async, A](fut: ApiFuture[A]): F[A] =
     Async[F]
       .async[A] { cb =>
         val cancel = Async[F].delay {
@@ -24,7 +24,9 @@ object FutureInterop {
           Some(cancel)
         }
       }
-      .void
+
+  def fromFuture_[F[_]: Async, A](fut: ApiFuture[A]): F[Unit] =
+    fromFuture(fut).void
 
   private def addCallback[A](fut: ApiFuture[A], cb: Either[Throwable, A] => Unit): Unit = {
     val apiFutureCallback = new ApiFutureCallback[A] {

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubBatchState.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubBatchState.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sources.pubsub
+
+import java.time.Instant
+
+/**
+ * Data held about a batch of messages pulled from a pubsub subscription
+ *
+ * @param currentDeadline
+ *   The deadline before which we must either ack, nack, or extend the deadline to something further
+ *   in the future. This is updated over time if we approach a deadline.
+ * @param ackIds
+ *   The IDs which are needed to ack all messages in the batch
+ */
+private case class PubsubBatchState(
+  currentDeadline: Instant,
+  ackIds: Vector[String]
+)

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubCheckpointer.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubCheckpointer.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sources.pubsub
+
+import cats.implicits._
+import cats.effect.kernel.Unique
+import cats.effect.{Async, Deferred, Ref, Sync}
+import com.google.cloud.pubsub.v1.stub.SubscriberStub
+import com.google.pubsub.v1.AcknowledgeRequest
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+import scala.jdk.CollectionConverters._
+import scala.concurrent.duration.Duration
+
+import com.snowplowanalytics.snowplow.sources.internal.Checkpointer
+import com.snowplowanalytics.snowplow.pubsub.FutureInterop
+import com.snowplowanalytics.snowplow.sources.pubsub.PubsubRetryOps.implicits._
+
+/**
+ * The Pubsub checkpointer
+ *
+ * @param subscription
+ *   Pubsub subscription name
+ * @param deferredResources
+ *   Resources needed so we can ack/nack messages. This is wrapped in `Deferred` because the
+ *   resources are not available until the application calls `.stream` on the `LowLevelSource`. This
+ *   is a limitation in the design of the common-streams Source interface.
+ */
+class PubsubCheckpointer[F[_]: Async](
+  subscription: PubsubSourceConfig.Subscription,
+  deferredResources: Deferred[F, PubsubCheckpointer.Resources[F]]
+) extends Checkpointer[F, Vector[Unique.Token]] {
+
+  import PubsubCheckpointer._
+
+  private implicit def logger: Logger[F] = Slf4jLogger.getLogger[F]
+
+  override def combine(x: Vector[Unique.Token], y: Vector[Unique.Token]): Vector[Unique.Token] =
+    x |+| y
+
+  override val empty: Vector[Unique.Token] = Vector.empty
+
+  /**
+   * Ack some batches of messages received from pubsub
+   *
+   * @param c
+   *   tokens which are keys to batch data held in the shared state
+   */
+  override def ack(c: Vector[Unique.Token]): F[Unit] =
+    for {
+      Resources(stub, refAckIds) <- deferredResources.get
+      ackDatas <- refAckIds.modify(m => (m -- c, c.flatMap(m.get)))
+      _ <- ackDatas.flatMap(_.ackIds).grouped(1000).toVector.traverse_ { ackIds =>
+             val request = AcknowledgeRequest.newBuilder.setSubscription(subscription.show).addAllAckIds(ackIds.asJava).build
+             val attempt = for {
+               apiFuture <- Sync[F].delay(stub.acknowledgeCallable.futureCall(request))
+               _ <- FutureInterop.fromFuture[F, com.google.protobuf.Empty](apiFuture)
+             } yield ()
+             attempt.retryingOnTransientGrpcFailures
+               .recoveringOnGrpcInvalidArgument { s =>
+                 // This can happen if ack IDs have expired before we acked
+                 Logger[F].info(s"Ignoring error from GRPC when acking: ${s.getDescription}")
+               }
+           }
+    } yield ()
+
+  /**
+   * Nack some batches of messages received from pubsub
+   *
+   * @param c
+   *   tokens which are keys to batch data held in the shared state
+   */
+  override def nack(c: Vector[Unique.Token]): F[Unit] =
+    for {
+      Resources(stub, refAckIds) <- deferredResources.get
+      ackDatas <- refAckIds.modify(m => (m -- c, c.flatMap(m.get)))
+      ackIds = ackDatas.flatMap(_.ackIds)
+      // A nack is just a modack with zero duration
+      _ <- Utils.modAck[F](subscription, stub, ackIds, Duration.Zero)
+    } yield ()
+}
+
+private object PubsubCheckpointer {
+
+  /**
+   * Resources needed by `PubsubCheckpointer` so it can ack/nack messages
+   *
+   * @param stub
+   *   The GRPC stub needed to execute the ack/nack RPCs
+   * @param refState
+   *   A map from tokens to the data held about a batch of messages received from pubsub. The map is
+   *   wrapped in a `Ref` because it is concurrently modified by the source adding new batches to
+   *   the state.
+   */
+  case class Resources[F[_]](stub: SubscriberStub, refState: Ref[F, Map[Unique.Token, PubsubBatchState]])
+
+}

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubRetryOps.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubRetryOps.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sources.pubsub
+
+import cats.implicits._
+import cats.effect.Async
+import com.google.api.gax.rpc.{ApiException, StatusCode}
+import io.grpc.Status
+import org.typelevel.log4cats.Logger
+import retry.RetryPolicies
+import retry.implicits._
+
+import scala.concurrent.duration.DurationDouble
+
+private[pubsub] object PubsubRetryOps {
+
+  object implicits {
+    implicit class Ops[F[_], A](val f: F[A]) extends AnyVal {
+
+      def retryingOnTransientGrpcFailures(implicit F: Async[F], L: Logger[F]): F[A] =
+        f.retryingOnSomeErrors(
+          isWorthRetrying = { e => isRetryableException(e).pure[F] },
+          policy          = RetryPolicies.fullJitter(1.second),
+          onError = { case (t, _) =>
+            Logger[F].info(t)(s"Pubsub retryable GRPC error will be retried: ${t.getMessage}")
+          }
+        )
+
+      def recoveringOnGrpcInvalidArgument(f2: Status => F[A])(implicit F: Async[F]): F[A] =
+        f.recoverWith {
+          case StatusFromThrowable(s) if s.getCode.equals(Status.Code.INVALID_ARGUMENT) =>
+            f2(s)
+        }
+    }
+  }
+
+  private object StatusFromThrowable {
+    def unapply(t: Throwable): Option[Status] =
+      Some(Status.fromThrowable(t))
+  }
+
+  def isRetryableException: Throwable => Boolean = {
+    case apiException: ApiException =>
+      apiException.getStatusCode.getCode match {
+        case StatusCode.Code.DEADLINE_EXCEEDED  => true
+        case StatusCode.Code.INTERNAL           => true
+        case StatusCode.Code.CANCELLED          => true
+        case StatusCode.Code.RESOURCE_EXHAUSTED => true
+        case StatusCode.Code.ABORTED            => true
+        case StatusCode.Code.UNKNOWN            => true
+        case StatusCode.Code.UNAVAILABLE        => !apiException.getMessage().contains("Server shutdownNow invoked")
+        case _                                  => false
+      }
+    case _ =>
+      false
+  }
+}

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
@@ -41,7 +41,7 @@ import com.snowplowanalytics.snowplow.pubsub.GcpUserAgent
  *   Name by which to identify Snowplow in the GRPC headers
  * @param maxMessagesPerPull
  *   How many pubsub messages to pull from the server in a single request.
- * @param debouceRequests
+ * @param debounceRequests
  *   Adds an artifical delay between consecutive requests to pubsub for more messages. Under some
  *   circumstances, this was found to slightly alleviate a problem in which pubsub might re-deliver
  *   the same messages multiple times.

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfig.scala
@@ -7,29 +7,64 @@
  */
 package com.snowplowanalytics.snowplow.sources.pubsub
 
+import cats.Show
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 import io.circe.config.syntax._
+import com.google.pubsub.v1.ProjectSubscriptionName
 
 import scala.concurrent.duration.FiniteDuration
 
 import com.snowplowanalytics.snowplow.pubsub.GcpUserAgent
 
+/**
+ * Configures the Pubsub Source
+ *
+ * @param subscription
+ *   Identifier of the pubsub subscription
+ * @param parallelPullFactor
+ *   Controls how many RPCs may be opened concurrently from the client to the PubSub server. The
+ *   maximum number of RPCs is equal to this factor multiplied by the number of available cpu cores.
+ *   Increasing this factor can increase the rate of events provided by the Source to the
+ *   application.
+ * @param durationPerAckExtension
+ *   Ack deadlines are extended for this duration. For common-streams apps this should be set
+ *   slightly larger than the maximum time we expect between app receiving the message and acking
+ *   the message. If a message is ever held by the app for longer than expected, then it's ok: the
+ *   Source will re-extend the ack deadline.
+ * @param minRemainingAckDeadline
+ *   Controls when ack deadlines are re-extended, for a message that is close to exceeding its ack
+ *   deadline.. For example, if `durationPerAckExtension` is `60 seconds` and
+ *   `minRemainingAckDeadline` is `0.1` then the Source will wait until there is `6 seconds` left of
+ *   the remining deadline, before re-extending the message deadline.
+ * @param gcpUserAgent
+ *   Name by which to identify Snowplow in the GRPC headers
+ * @param maxMessagesPerPull
+ *   How many pubsub messages to pull from the server in a single request.
+ * @param debouceRequests
+ *   Adds an artifical delay between consecutive requests to pubsub for more messages. Under some
+ *   circumstances, this was found to slightly alleviate a problem in which pubsub might re-deliver
+ *   the same messages multiple times.
+ */
 case class PubsubSourceConfig(
   subscription: PubsubSourceConfig.Subscription,
   parallelPullFactor: BigDecimal,
-  bufferMaxBytes: Int,
-  maxAckExtensionPeriod: FiniteDuration,
-  minDurationPerAckExtension: FiniteDuration,
-  maxDurationPerAckExtension: FiniteDuration,
+  durationPerAckExtension: FiniteDuration,
+  minRemainingAckDeadline: BigDecimal,
   gcpUserAgent: GcpUserAgent,
-  shutdownTimeout: FiniteDuration,
-  maxPullsPerTransportChannel: Int
+  maxMessagesPerPull: Int,
+  debounceRequests: FiniteDuration
 )
 
 object PubsubSourceConfig {
 
   case class Subscription(projectId: String, subscriptionId: String)
+
+  object Subscription {
+    implicit def show: Show[Subscription] = Show[Subscription] { s =>
+      ProjectSubscriptionName.of(s.projectId, s.subscriptionId).toString
+    }
+  }
 
   private implicit def subscriptionDecoder: Decoder[Subscription] =
     Decoder.decodeString

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/Utils.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/Utils.scala
@@ -34,6 +34,7 @@ private[pubsub] object Utils {
         .setAckDeadlineSeconds(duration.toSeconds.toInt)
         .build
       val io = for {
+        _ <- Logger[F].debug(s"Modifying ack deadline for ${ackIds.length} messages by ${duration.toSeconds} seconds")
         apiFuture <- Sync[F].delay(stub.modifyAckDeadlineCallable.futureCall(request))
         _ <- FutureInterop.fromFuture_(apiFuture)
       } yield ()

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/Utils.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sources/pubsub/Utils.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sources.pubsub
+
+import cats.effect.{Async, Sync}
+import cats.implicits._
+import org.typelevel.log4cats.Logger
+
+import com.google.cloud.pubsub.v1.stub.SubscriberStub
+import com.google.pubsub.v1.ModifyAckDeadlineRequest
+import com.snowplowanalytics.snowplow.sources.pubsub.PubsubRetryOps.implicits._
+import com.snowplowanalytics.snowplow.pubsub.FutureInterop
+
+import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
+
+private[pubsub] object Utils {
+
+  def modAck[F[_]: Async: Logger](
+    subscription: PubsubSourceConfig.Subscription,
+    stub: SubscriberStub,
+    ackIds: Vector[String],
+    duration: FiniteDuration
+  ): F[Unit] =
+    ackIds.grouped(1000).toVector.traverse_ { group =>
+      val request = ModifyAckDeadlineRequest.newBuilder
+        .setSubscription(subscription.show)
+        .addAllAckIds(group.asJava)
+        .setAckDeadlineSeconds(duration.toSeconds.toInt)
+        .build
+      val io = for {
+        apiFuture <- Sync[F].delay(stub.modifyAckDeadlineCallable.futureCall(request))
+        _ <- FutureInterop.fromFuture_(apiFuture)
+      } yield ()
+
+      io.retryingOnTransientGrpcFailures
+        .recoveringOnGrpcInvalidArgument { s =>
+          // This can happen if ack IDs were acked before we modAcked
+          Logger[F].info(s"Ignoring error from GRPC when modifying ack IDs: ${s.getDescription}")
+        }
+    }
+
+}

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sources/pubsub/PubsubSourceConfigSpec.scala
@@ -41,15 +41,13 @@ class PubsubSourceConfigSpec extends Specification {
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
     val expected = PubsubSourceConfig(
-      subscription                = PubsubSourceConfig.Subscription("my-project", "my-subscription"),
-      parallelPullFactor          = BigDecimal(0.5),
-      bufferMaxBytes              = 10000000,
-      maxAckExtensionPeriod       = 1.hour,
-      minDurationPerAckExtension  = 1.minute,
-      maxDurationPerAckExtension  = 10.minutes,
-      gcpUserAgent                = GcpUserAgent("Snowplow OSS", "example-version"),
-      shutdownTimeout             = 30.seconds,
-      maxPullsPerTransportChannel = 16
+      subscription            = PubsubSourceConfig.Subscription("my-project", "my-subscription"),
+      parallelPullFactor      = BigDecimal(0.5),
+      durationPerAckExtension = 1.minute,
+      minRemainingAckDeadline = BigDecimal(0.1),
+      gcpUserAgent            = GcpUserAgent("Snowplow OSS", "example-version"),
+      maxMessagesPerPull      = 1000,
+      debounceRequests        = 100.millis
     )
 
     result.as[Wrapper] must beRight.like { case w: Wrapper =>


### PR DESCRIPTION
The previous implementation of the PubSub Source was a wrapper around `Subscriber` provided by the 3rd-party pubsub sdk. That `Subscriber` is a wrapper around a lower-level GRPC stub. It used the "Streaming Pull" GRPC method to fetch messages from PubSub.

This commit abandons using the `Subscriber` and instead wraps the GRPC stub directly. It uses the "Unary Pull" GRPC method to fetch messages from PubSub.

We found that "Unary Pull" alleviates a problem in which PubSub occasionally re-delivers the same messages, causing downstream duplicates. The problem happened especially in apps like Lake Loader, which builds up a very large number of un-acked messages and then acks them all in one go at the end of a timed window.

Compared with the previous Source implementation it has these differences in behaviour:

- Previously, the 3rd-party `Subscriber` managed ack extensions (a.k.a. modifying ack deadlines). Ack extension periods were adjusted dynamically according to runtime heuristics of message processing times. Whereas in this new Source, the ack extension period is a fixed configurable period.
- Previously, the `Subscriber` periodically mod-acked all unacked messages currently held in memory. Whereas the new Source only mod-acks messages when they are approaching their ack deadline. This is an improvement for apps like Lake Loader which might have a very large number of outstanding unacked messages.
- Unary Pull has _slightly_ worse latency compared to Streaming Pull. I consider this ok for common-streams apps, where the latency caused by the Source is negligible compared to other latencies in the app.
- Arguably, "Unary Pull" is a neater fit (less hacky) for a common-streams Source. Now, we simply pull a batch when a batch is needed.