### PR TITLE
Sources should report stream latency of stuck events

### DIFF
--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/MetricsSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/runtime/MetricsSpec.scala
@@ -76,7 +76,7 @@ object TestMetrics {
     ref: Ref[IO, TestState],
     emptyState: TestState,
     config: Option[Metrics.StatsdConfig]
-  ) extends Metrics[IO, TestState](ref, emptyState, config) {
+  ) extends Metrics[IO, TestState](ref, IO.pure(emptyState), config) {
     def count(c: Int)           = ref.update(s => s.copy(counter = s.counter + c))
     def time(t: FiniteDuration) = ref.update(s => s.copy(timer = s.timer + t))
   }

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/EventProcessingConfig.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/EventProcessingConfig.scala
@@ -25,8 +25,11 @@ import scala.concurrent.duration.FiniteDuration
  *   Whether to open a new [[EventProcessor]] to handle a timed window of events (e.g. for the
  *   transformer) or whether to feed events to a single [[EventProcessor]] in a continuous endless
  *   stream (e.g. Enrich)
+ *
+ * @param latencyConsumer
+ *   common-streams apps should use the latencyConsumer to set the latency metric.
  */
-case class EventProcessingConfig(windowing: EventProcessingConfig.Windowing)
+case class EventProcessingConfig[F[_]](windowing: EventProcessingConfig.Windowing, latencyConsumer: FiniteDuration => F[Unit])
 
 object EventProcessingConfig {
 

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
@@ -33,7 +33,7 @@ trait SourceAndAck[F[_]] {
    * @return
    *   A stream which should be compiled and drained
    */
-  def stream(config: EventProcessingConfig, processor: EventProcessor[F]): Stream[F, Nothing]
+  def stream(config: EventProcessingConfig[F], processor: EventProcessor[F]): Stream[F, Nothing]
 
   /**
    * Reports on whether the source of events is healthy

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/SourceAndAck.scala
@@ -10,6 +10,7 @@ package com.snowplowanalytics.snowplow.sources
 import cats.Show
 import cats.implicits._
 import fs2.Stream
+
 import scala.concurrent.duration.FiniteDuration
 
 /**
@@ -48,6 +49,22 @@ trait SourceAndAck[F[_]] {
    * healthy. If any event is "stuck" then latency is high and the probe should report unhealthy.
    */
   def isHealthy(maxAllowedProcessingLatency: FiniteDuration): F[SourceAndAck.HealthStatus]
+
+  /**
+   * Latency of the message that is currently being processed by the downstream application
+   *
+   * The returned value is `None` if this `SourceAndAck` is currently awaiting messages from
+   * upstream, e.g. it is doing a remote fetch.
+   *
+   * The returned value is `Some` if this `SourceAndAck` has emitted a message downstream to the
+   * application, and it is waiting for the downstream app to "pull" the next message from this
+   * `SourceAndAck`.
+   *
+   * This value should be used as the initial latency at the start of a statsd metrics reporting
+   * period. This ensures the app reports non-zero latency even when the app is stuck (e.g. cannot
+   * load events to destination).
+   */
+  def currentStreamLatency: F[Option[FiniteDuration]]
 }
 
 object SourceAndAck {

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/TokenedEvents.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/TokenedEvents.scala
@@ -11,7 +11,6 @@ import cats.effect.kernel.Unique
 import fs2.Chunk
 
 import java.nio.ByteBuffer
-import java.time.Instant
 
 /**
  * The events as they are fed into a [[EventProcessor]]
@@ -22,12 +21,8 @@ import java.time.Instant
  *   The [[EventProcessor]] must emit this token after it has fully processed the batch of events.
  *   When the [[EventProcessor]] emits the token, it is an instruction to the [[SourceAndAck]] to
  *   ack/checkpoint the events.
- * @param earliestSourceTstamp
- *   The timestamp that an event was originally written to the source stream. Used for calculating
- *   the latency metric.
  */
 case class TokenedEvents(
   events: Chunk[ByteBuffer],
-  ack: Unique.Token,
-  earliestSourceTstamp: Option[Instant]
+  ack: Unique.Token
 )

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelEvents.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelEvents.scala
@@ -10,16 +10,19 @@ package com.snowplowanalytics.snowplow.sources.internal
 import fs2.Chunk
 
 import java.nio.ByteBuffer
-import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * The events and checkpointable item emitted by a LowLevelSource
  *
  * This library uses LowLevelEvents internally, but it is never exposed to the high level event
  * processor
+ *
+ * @param earliestSourceTstamp
+ *   A point in time, represented as a `FiniteDuration` since epoch
  */
 case class LowLevelEvents[C](
   events: Chunk[ByteBuffer],
   ack: C,
-  earliestSourceTstamp: Option[Instant]
+  earliestSourceTstamp: Option[FiniteDuration]
 )

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSource.scala
@@ -17,8 +17,7 @@ import fs2.{Pipe, Pull, Stream}
 import org.typelevel.log4cats.{Logger, SelfAwareStructuredLogger}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.duration.{DurationLong, FiniteDuration}
-import java.time.Instant
+import scala.concurrent.duration.{Duration, DurationLong, FiniteDuration}
 import com.snowplowanalytics.snowplow.sources.{EventProcessingConfig, EventProcessor, SourceAndAck, TokenedEvents}
 
 /**
@@ -44,16 +43,12 @@ private[sources] trait LowLevelSource[F[_], C] {
    * rebalancing.
    *
    * A new [[EventProcessor]] will be invoked for each inner stream
-   */
-  def stream: Stream[F, Stream[F, LowLevelEvents[C]]]
-
-  /**
-   * The last time this source was known to be alive and healthy
    *
-   * The returned value is FiniteDuration since the unix epoch, i.e. the value returned by
-   * `Sync[F].realTime`
+   * The inner stream should periodically emit `None` as a signal that it is alive and healthy, even
+   * when there are no events on the stream. Failure to emit frequently will result in the
+   * `SourceAndAck` reporting itself as unhealthy.
    */
-  def lastLiveness: F[FiniteDuration]
+  def stream: Stream[F, Stream[F, Option[LowLevelEvents[C]]]]
 }
 
 private[sources] object LowLevelSource {
@@ -66,31 +61,36 @@ private[sources] object LowLevelSource {
    * Map is keyed by Token, corresponding to a batch of `TokenedEvents`. Map values are `C`s which
    * is how to ack/checkpoint the batch.
    */
-  private type State[C] = Map[Unique.Token, C]
+  private type AcksState[C] = Map[Unique.Token, C]
 
-  /**
-   * Timestamps of the instantaneous state of the Source
-   *
-   * @param wallTime
-   *   The real time (since epoch) that this Source emitted a batch to the downstream app for
-   *   processing.
-   * @param streamTime
-   *   For the last batch to be emitted downstream, this is the earliest timestamp according to the
-   *   source, i.e. time the event was written to the source stream. It is None if this stream type
-   *   does not record timestamps, e.g. Kafka under some circumstances.
-   *
-   * Note that both values represent instants of time. They have different types (FiniteDuration and
-   * Instant) but that is just for convenience to match the incoming data.
-   */
-  private case class LastEmittedTstamps(wallTime: FiniteDuration, streamTime: Option[Instant])
+  private sealed trait InternalState
 
-  /**
-   * Mutable state used for measuring the event-processing latency from this source
-   *
-   * Holds a `LastEmittedTstamps` for the batch that was last emitted downstream for processing. It
-   * is None if there is no batch currently being processed downstream.
-   */
-  private type LatencyRef[F[_]] = Ref[F, Option[LastEmittedTstamps]]
+  private object InternalState {
+
+    /**
+     * The Source is awaiting the downstream processor to pull another message from us
+     *
+     * @param since
+     *   Timestamp of when the last message was emitted downstream. A point in time represented as
+     *   FiniteDuration since the epoch.
+     * @param streamTstamp
+     *   For the last last batch to be emitted downstream, this is the earliest timestamp according
+     *   to the source, i.e. time the event was written to the source stream. It is None if this
+     *   stream type does not record timestamps, e.g. Kafka under some circumstances.
+     */
+    case class AwaitingDownstream(since: FiniteDuration, streamTstamp: Option[FiniteDuration]) extends InternalState
+
+    /**
+     * The Source is awaiting the upstream remote source to provide more messages
+     *
+     * @param since
+     *   Timestamp of when the last message was received up upstream. A point in time represented as
+     *   FiniteDuration since the epoch.
+     */
+    case class AwaitingUpstream(since: FiniteDuration) extends InternalState
+
+    case object Disconnected extends InternalState
+  }
 
   /**
    * Lifts the internal [[LowLevelSource]] into a [[SourceAndAck]], which is the public API of this
@@ -98,23 +98,22 @@ private[sources] object LowLevelSource {
    */
   def toSourceAndAck[F[_]: Async, C](source: LowLevelSource[F, C]): F[SourceAndAck[F]] =
     for {
-      latencyRef <- Ref[F].of(Option.empty[LastEmittedTstamps])
-      isConnectedRef <- Ref[F].of(false)
-    } yield sourceAndAckImpl(source, latencyRef, isConnectedRef)
+      stateRef <- Ref[F].of[InternalState](InternalState.Disconnected)
+    } yield sourceAndAckImpl(source, stateRef)
 
   private def sourceAndAckImpl[F[_]: Async, C](
     source: LowLevelSource[F, C],
-    latencyRef: LatencyRef[F],
-    isConnectedRef: Ref[F, Boolean]
+    stateRef: Ref[F, InternalState]
   ): SourceAndAck[F] = new SourceAndAck[F] {
-    def stream(config: EventProcessingConfig, processor: EventProcessor[F]): Stream[F, Nothing] = {
+    def stream(config: EventProcessingConfig[F], processor: EventProcessor[F]): Stream[F, Nothing] = {
       val str = for {
         s2 <- source.stream
         acksRef <- Stream.bracket(Ref[F].of(Map.empty[Unique.Token, C]))(nackUnhandled(source.checkpointer, _))
-        _ <- Stream.bracket(isConnectedRef.set(true))(_ => isConnectedRef.set(false))
+        now <- Stream.eval(Sync[F].realTime)
+        _ <- Stream.bracket(stateRef.set(InternalState.AwaitingUpstream(now)))(_ => stateRef.set(InternalState.Disconnected))
       } yield {
         val tokenedSources = s2
-          .through(monitorLatency(latencyRef))
+          .through(monitorLatency(config, stateRef))
           .through(tokened(acksRef))
           .through(windowed(config.windowing))
 
@@ -132,27 +131,27 @@ private[sources] object LowLevelSource {
     }
 
     def isHealthy(maxAllowedProcessingLatency: FiniteDuration): F[SourceAndAck.HealthStatus] =
-      (isConnectedRef.get, latencyRef.get, source.lastLiveness, Sync[F].realTime).mapN {
-        case (false, _, _, _) =>
+      (stateRef.get, Sync[F].realTime).mapN {
+        case (InternalState.Disconnected, _) =>
           SourceAndAck.Disconnected
-        case (_, Some(LastEmittedTstamps(lastPullTime, _)), _, now) if now - lastPullTime > maxAllowedProcessingLatency =>
-          SourceAndAck.LaggingEventProcessor(now - lastPullTime)
-        case (_, _, lastLiveness, now) if now - lastLiveness > maxAllowedProcessingLatency =>
-          SourceAndAck.InactiveSource(now - lastLiveness)
+        case (InternalState.AwaitingDownstream(since, _), now) if now - since > maxAllowedProcessingLatency =>
+          SourceAndAck.LaggingEventProcessor(now - since)
+        case (InternalState.AwaitingUpstream(since), now) if now - since > maxAllowedProcessingLatency =>
+          SourceAndAck.InactiveSource(now - since)
         case _ => SourceAndAck.Healthy
       }
 
     def currentStreamLatency: F[Option[FiniteDuration]] =
-      latencyRef.get.flatMap {
-        case Some(LastEmittedTstamps(_, Some(tstamp))) =>
+      stateRef.get.flatMap {
+        case InternalState.AwaitingDownstream(_, Some(tstamp)) =>
           Sync[F].realTime.map { now =>
-            Some(now - tstamp.toEpochMilli.millis)
+            Some(now - tstamp)
           }
         case _ => none.pure[F]
       }
   }
 
-  private def nackUnhandled[F[_]: Monad, C](checkpointer: Checkpointer[F, C], ref: Ref[F, State[C]]): F[Unit] =
+  private def nackUnhandled[F[_]: Monad, C](checkpointer: Checkpointer[F, C], ref: Ref[F, AcksState[C]]): F[Unit] =
     ref.get
       .flatMap { map =>
         checkpointer.nack(checkpointer.combineAll(map.values))
@@ -163,29 +162,41 @@ private[sources] object LowLevelSource {
    *
    * The token can later be exchanged for the original checkpointable item
    */
-  private def tokened[F[_]: Sync, C](ref: Ref[F, State[C]]): Pipe[F, LowLevelEvents[C], TokenedEvents] =
-    _.evalMap { case LowLevelEvents(events, ack, earliestSourceTstamp) =>
+  private def tokened[F[_]: Sync, C](ref: Ref[F, AcksState[C]]): Pipe[F, LowLevelEvents[C], TokenedEvents] =
+    _.evalMap { case LowLevelEvents(events, ack, _) =>
       for {
         token <- Unique[F].unique
         _ <- ref.update(_ + (token -> ack))
-      } yield TokenedEvents(events, token, earliestSourceTstamp)
+      } yield TokenedEvents(events, token)
     }
 
   /**
    * An fs2 Pipe which records what time (duration since epoch) we last emitted a batch downstream
    * for processing
    */
-  private def monitorLatency[F[_]: Sync, C](ref: LatencyRef[F]): Pipe[F, LowLevelEvents[C], LowLevelEvents[C]] = {
+  private def monitorLatency[F[_]: Sync, C](
+    config: EventProcessingConfig[F],
+    ref: Ref[F, InternalState]
+  ): Pipe[F, Option[LowLevelEvents[C]], LowLevelEvents[C]] = {
 
-    def go(source: Stream[F, LowLevelEvents[C]]): Pull[F, LowLevelEvents[C], Unit] =
+    def go(source: Stream[F, Option[LowLevelEvents[C]]]): Pull[F, LowLevelEvents[C], Unit] =
       source.pull.uncons1.flatMap {
         case None => Pull.done
-        case Some((pulled, source)) =>
+        case Some((Some(pulled), source)) =>
           for {
             now <- Pull.eval(Sync[F].realTime)
-            _ <- Pull.eval(ref.set(Some(LastEmittedTstamps(now, pulled.earliestSourceTstamp))))
+            latency = pulled.earliestSourceTstamp.fold(Duration.Zero)(now - _)
+            _ <- Pull.eval(config.latencyConsumer(latency))
+            _ <- Pull.eval(ref.set(InternalState.AwaitingDownstream(now, pulled.earliestSourceTstamp)))
             _ <- Pull.output1(pulled)
-            _ <- Pull.eval(ref.set(None))
+            _ <- Pull.eval(ref.set(InternalState.AwaitingUpstream(now)))
+            _ <- go(source)
+          } yield ()
+        case Some((None, source)) =>
+          for {
+            now <- Pull.eval(Sync[F].realTime)
+            _ <- Pull.eval(config.latencyConsumer(Duration.Zero))
+            _ <- Pull.eval(ref.set(InternalState.AwaitingUpstream(now)))
             _ <- go(source)
           } yield ()
       }
@@ -215,11 +226,11 @@ private[sources] object LowLevelSource {
    */
   private def messageSink[F[_]: Async, C](
     processor: EventProcessor[F],
-    ref: Ref[F, State[C]],
+    ref: Ref[F, AcksState[C]],
     checkpointer: Checkpointer[F, C],
     control: EagerWindows.Control[F]
   ): Pipe[F, TokenedEvents, Nothing] =
-    _.evalTap { case TokenedEvents(events, _, _) =>
+    _.evalTap { case TokenedEvents(events, _) =>
       Logger[F].debug(s"Batch of ${events.size} events received from the source stream")
     }
       .through(processor)

--- a/modules/streams-core/src/test/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSourceSpec.scala
+++ b/modules/streams-core/src/test/scala/com.snowplowanalytics.snowplow/sources/internal/LowLevelSourceSpec.scala
@@ -16,7 +16,7 @@ import cats.effect.testing.specs2.CatsEffect
 import fs2.{Chunk, Stream}
 import org.specs2.Specification
 
-import scala.concurrent.duration.{DurationLong, FiniteDuration}
+import scala.concurrent.duration.{Duration, DurationLong, FiniteDuration}
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 
@@ -43,22 +43,28 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
       use a short first window according to the configuration $windowed5
 
     When reporting healthy status
-      report healthy when there are no events $health1
-      report lagging if there are unprocessed events $health2
-      report healthy if events are processed but not yet acked (e.g. a batch-oriented loader) $health3
-      report healthy after all events have been processed and acked $health4
-      report disconnected while source is in between two active streams of events (e.g. during kafka rebalance) $health5
-      report unhealthy if the underlying low level source is lagging $health6
+      report healthy when there are no events but the source emits periodic liveness pings $health1
+      report unhealthy when there are no events and no liveness pings $health2
+      report lagging if there are unprocessed events $health3
+      report healthy if events are processed but not yet acked (e.g. a batch-oriented loader) $health4
+      report healthy after all events have been processed and acked $health5
+      report disconnected while source is in between two active streams of events (e.g. during kafka rebalance) $health6
+      report unhealthy if the underlying low level source is lagging $health7
 
     When reporting currentStreamLatency
       report no timestamp when there are no events $latency1
       report a timestamp if there are unprocessed events $latency2
       report no timestamp after events are processed $latency3
+
+    When pushing latency metrics
+      report no metric when there are no events and no liveness pings $latencyMetric1
+      report zero latency when there are no events, but regular liveness pings $latencyMetric2
+      report non-zero latency when the source emits timestamped events $latencyMetric3
   """
 
   def e1 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 5,
@@ -115,7 +121,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def e2 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 100,
@@ -150,7 +156,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def e3 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 5,
@@ -201,7 +207,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def windowed1 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(45.seconds, 1.0, 2))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(45.seconds, 1.0, 2), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 5,
@@ -309,7 +315,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def windowed2 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(45.seconds, 1.0, 2))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(45.seconds, 1.0, 2), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = Int.MaxValue,
@@ -342,7 +348,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def windowed3 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(10.minutes, 1.0, 2))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(10.minutes, 1.0, 2), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 5,
@@ -387,7 +393,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def windowed4 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(10.seconds, 1.0, numEagerWindows = 4))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(10.seconds, 1.0, numEagerWindows = 4), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance  = Int.MaxValue,
@@ -454,7 +460,8 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
         duration           = 60.seconds,
         firstWindowScaling = 0.25, // so first window is 15 seconds
         numEagerWindows    = 2
-      )
+      ),
+      _ => IO.unit
     )
 
     val testConfig = TestSourceConfig(
@@ -502,13 +509,35 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def health1 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
+
+    // A source that emits periodic liveness pings
+    val lowLevelSource = new LowLevelSource[IO, Unit] {
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.awakeDelay[IO](1.second).map(_ => None))
+    }
+
+    val io = for {
+      refActions <- Ref[IO].of(Vector.empty[Action])
+      sourceAndAck <- LowLevelSource.toSourceAndAck(lowLevelSource)
+      processor = testProcessor(refActions, TestSourceConfig(1, 1, 1.second, 1.second))
+      fiber <- sourceAndAck.stream(config, processor).compile.drain.start
+      _ <- IO.sleep(1.hour)
+      health <- sourceAndAck.isHealthy(10.seconds)
+      _ <- fiber.cancel
+    } yield health must beEqualTo(SourceAndAck.Healthy)
+
+    TestControl.executeEmbed(io)
+  }
+
+  def health2 = {
+
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     // A source that emits nothing
     val lowLevelSource = new LowLevelSource[IO, Unit] {
-      def checkpointer: Checkpointer[IO, Unit]                 = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
-      def stream: Stream[IO, Stream[IO, LowLevelEvents[Unit]]] = Stream.emit(Stream.never[IO])
-      def lastLiveness: IO[FiniteDuration]                     = IO.realTime
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.never[IO])
     }
 
     val io = for {
@@ -519,14 +548,14 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
       _ <- IO.sleep(1.hour)
       health <- sourceAndAck.isHealthy(1.nanosecond)
       _ <- fiber.cancel
-    } yield health must beEqualTo(SourceAndAck.Healthy)
+    } yield health must beEqualTo(SourceAndAck.InactiveSource(1.hour))
 
     TestControl.executeEmbed(io)
   }
 
-  def health2 = {
+  def health3 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = Int.MaxValue,
@@ -548,9 +577,9 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
     TestControl.executeEmbed(io)
   }
 
-  def health3 = {
+  def health4 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(1.hour, 1.0, 2))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(1.hour, 1.0, 2), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = Int.MaxValue,
@@ -572,9 +601,9 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
     TestControl.executeEmbed(io)
   }
 
-  def health4 = {
+  def health5 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = 1,
@@ -589,25 +618,24 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
       processor = testProcessor(refActions, testConfig)
       fiber <- sourceAndAck.stream(config, processor).compile.drain.start
       _ <- IO.sleep(5.minutes)
-      health <- sourceAndAck.isHealthy(1.microsecond)
+      health <- sourceAndAck.isHealthy(2.seconds)
       _ <- fiber.cancel
     } yield health must beEqualTo(SourceAndAck.Healthy)
 
     TestControl.executeEmbed(io)
   }
 
-  def health5 = {
+  def health6 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     // A source that emits one batch per inner stream, with a 5 minute "rebalancing" in between
     val lowLevelSource = new LowLevelSource[IO, Unit] {
       def checkpointer: Checkpointer[IO, Unit] = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
-      def stream: Stream[IO, Stream[IO, LowLevelEvents[Unit]]] =
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] =
         Stream.fixedDelay[IO](5.minutes).map { _ =>
-          Stream.emit(LowLevelEvents(Chunk.empty, (), None))
+          Stream.emit(Some(LowLevelEvents(Chunk.empty, (), None)))
         }
-      def lastLiveness: IO[FiniteDuration] = IO.realTime
     }
 
     val io = for {
@@ -623,14 +651,13 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
     TestControl.executeEmbed(io)
   }
 
-  def health6 = {
+  def health7 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val lowLevelSource = new LowLevelSource[IO, Unit] {
-      def checkpointer: Checkpointer[IO, Unit]                 = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
-      def stream: Stream[IO, Stream[IO, LowLevelEvents[Unit]]] = Stream.emit(Stream.never[IO])
-      def lastLiveness: IO[FiniteDuration]                     = IO.realTime.map(_ - 10.seconds)
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.never[IO])
     }
 
     val io = for {
@@ -641,22 +668,21 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
       _ <- IO.sleep(5.minutes)
       health <- sourceAndAck.isHealthy(5.seconds)
       _ <- fiber.cancel
-    } yield health must beEqualTo(SourceAndAck.InactiveSource(10.seconds))
+    } yield health must beEqualTo(SourceAndAck.InactiveSource(5.minutes))
 
     TestControl.executeEmbed(io)
   }
 
-  /** Specs for health check */
+  /** Specs for currentStreamLatency */
 
   def latency1 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     // A source that emits nothing
     val lowLevelSource = new LowLevelSource[IO, Unit] {
-      def checkpointer: Checkpointer[IO, Unit]                 = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
-      def stream: Stream[IO, Stream[IO, LowLevelEvents[Unit]]] = Stream.emit(Stream.never[IO])
-      def lastLiveness: IO[FiniteDuration]                     = IO.realTime
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.never[IO])
     }
 
     val io = for {
@@ -674,7 +700,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def latency2 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing)
+    val config = EventProcessingConfig(EventProcessingConfig.NoWindowing, _ => IO.unit)
 
     val streamTstamp = Instant.parse("2024-01-02T03:04:05.123Z")
     val testConfig = TestSourceConfig(
@@ -701,7 +727,7 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
 
   def latency3 = {
 
-    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(1.hour, 1.0, 2))
+    val config = EventProcessingConfig(EventProcessingConfig.TimedWindows(1.hour, 1.0, 2), _ => IO.unit)
 
     val testConfig = TestSourceConfig(
       batchesPerRebalance = Int.MaxValue,
@@ -719,6 +745,81 @@ class LowLevelSourceSpec extends Specification with CatsEffect {
       reportedLatency <- sourceAndAck.currentStreamLatency
       _ <- fiber.cancel
     } yield reportedLatency must beNone
+
+    TestControl.executeEmbed(io)
+  }
+
+  /** Specs for latency metric */
+
+  def latencyMetric1 = {
+
+    // A source that emits nothing
+    val lowLevelSource = new LowLevelSource[IO, Unit] {
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.never[IO])
+    }
+
+    val io = for {
+      refActions <- Ref[IO].of(Vector.empty[Action])
+      sourceAndAck <- LowLevelSource.toSourceAndAck(lowLevelSource)
+      processor = testProcessor(refActions, TestSourceConfig(1, 1, 1.second, 1.second))
+      refLatencies <- Ref[IO].of(Vector.empty[FiniteDuration])
+      config = EventProcessingConfig(EventProcessingConfig.NoWindowing, metric => refLatencies.update(_ :+ metric))
+      fiber <- sourceAndAck.stream(config, processor).compile.drain.start
+      _ <- IO.sleep(1.hour)
+      latencyMetrics <- refLatencies.get
+      _ <- fiber.cancel
+    } yield latencyMetrics must beEmpty
+
+    TestControl.executeEmbed(io)
+  }
+
+  def latencyMetric2 = {
+
+    // A source that emits periodic liveness pings
+    val lowLevelSource = new LowLevelSource[IO, Unit] {
+      def checkpointer: Checkpointer[IO, Unit]                         = Checkpointer.acksOnly[IO, Unit](_ => IO.unit)
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[Unit]]]] = Stream.emit(Stream.awakeDelay[IO](1.second).map(_ => None))
+    }
+
+    val io = for {
+      refActions <- Ref[IO].of(Vector.empty[Action])
+      sourceAndAck <- LowLevelSource.toSourceAndAck(lowLevelSource)
+      processor = testProcessor(refActions, TestSourceConfig(1, 1, 1.second, 1.second))
+      refLatencies <- Ref[IO].of(Vector.empty[FiniteDuration])
+      config = EventProcessingConfig(EventProcessingConfig.NoWindowing, metric => refLatencies.update(_ :+ metric))
+      fiber <- sourceAndAck.stream(config, processor).compile.drain.start
+      _ <- IO.sleep(1.hour)
+      latencyMetrics <- refLatencies.get
+      _ <- fiber.cancel
+    } yield latencyMetrics.toSet must contain(exactly(Duration.Zero))
+
+    TestControl.executeEmbed(io)
+  }
+
+  def latencyMetric3 = {
+
+    val streamTstamp = Instant.parse("2024-01-02T03:04:05.123Z")
+    val testConfig = TestSourceConfig(
+      batchesPerRebalance = Int.MaxValue,
+      eventsPerBatch      = 2,
+      timeBetweenBatches  = 1.second,
+      timeToProcessBatch  = 1.second,
+      streamTstamp        = streamTstamp
+    )
+
+    val io = for {
+      _ <- IO.sleep(streamTstamp.toEpochMilli.millis + 2.minutes)
+      refActions <- Ref[IO].of(Vector.empty[Action])
+      sourceAndAck <- LowLevelSource.toSourceAndAck(testLowLevelSource(refActions, testConfig))
+      processor = windowedProcessor(refActions, testConfig)
+      refLatencies <- Ref[IO].of(Vector.empty[FiniteDuration])
+      config = EventProcessingConfig(EventProcessingConfig.NoWindowing, metric => refLatencies.update(_ :+ metric))
+      fiber <- sourceAndAck.stream(config, processor).compile.drain.start
+      _ <- IO.sleep(10.seconds)
+      latencyMetrics <- refLatencies.get
+      _ <- fiber.cancel
+    } yield latencyMetrics must contain(beBetween(120.seconds, 130.seconds))
 
     TestControl.executeEmbed(io)
   }
@@ -755,7 +856,7 @@ object LowLevelSourceSpec {
     val start = IO.realTimeInstant.flatMap(t => ref.update(_ :+ Action.ProcessorStartedWindow(t.toString)))
     val end   = IO.realTimeInstant.flatMap(t => ref.update(_ :+ Action.ProcessorReachedEndOfWindow(t.toString)))
 
-    val middle = in.evalMap { case TokenedEvents(events, token, _) =>
+    val middle = in.evalMap { case TokenedEvents(events, token) =>
       val deserialized = events.map(byteBuffer => StandardCharsets.UTF_8.decode(byteBuffer).toString).toList
       for {
         now <- IO.realTimeInstant
@@ -784,7 +885,7 @@ object LowLevelSourceSpec {
         tokens <- checkpoints.get
       } yield tokens.reverse
 
-      val middle = in.evalMap { case TokenedEvents(events, token, _) =>
+      val middle = in.evalMap { case TokenedEvents(events, token) =>
         val deserialized = events.map(byteBuffer => StandardCharsets.UTF_8.decode(byteBuffer).toString).toList
         for {
           now <- IO.realTimeInstant
@@ -803,6 +904,7 @@ object LowLevelSourceSpec {
    *
    *   - It emits batches of events at regular intervals
    *   - It "rebalances" (like Kafka) after every few batches, which means it emits a new stream
+   *   - It periodically emits `None`s to report its liveness
    *   - It uses a ref to record which events got checkpointed
    */
   def testLowLevelSource(ref: Ref[IO, Vector[Action]], config: TestSourceConfig): LowLevelSource[IO, List[String]] =
@@ -812,7 +914,7 @@ object LowLevelSourceSpec {
           ref.update(_ :+ Action.Checkpointed(toCheckpoint))
       }
 
-      def stream: Stream[IO, Stream[IO, LowLevelEvents[List[String]]]] =
+      def stream: Stream[IO, Stream[IO, Option[LowLevelEvents[List[String]]]]] =
         Stream.eval(Ref[IO].of(0)).flatMap { counter =>
           Stream.unit.repeat.map { _ =>
             Stream
@@ -822,16 +924,22 @@ object LowLevelSourceSpec {
                   .map { numbers =>
                     val events  = numbers.map(_.toString)
                     val asBytes = Chunk.from(events).map(e => ByteBuffer.wrap(e.getBytes(StandardCharsets.UTF_8)))
-                    LowLevelEvents(events = asBytes, ack = events.toList, earliestSourceTstamp = Some(config.streamTstamp))
+                    Some(
+                      LowLevelEvents(
+                        events               = asBytes,
+                        ack                  = events.toList,
+                        earliestSourceTstamp = Some(config.streamTstamp.toEpochMilli.millis)
+                      )
+                    )
                   }
               }
               .flatMap { e =>
                 Stream.emit(e) ++ Stream.sleep[IO](config.timeBetweenBatches).drain
               }
               .repeatN(config.batchesPerRebalance.toLong)
+              .mergeHaltL(Stream.awakeDelay[IO](1.second).map(_ => None).repeat)
           }
         }
-      def lastLiveness: IO[FiniteDuration] = IO.realTime
     }
 
 }


### PR DESCRIPTION
Currently in common-streams apps, the _application_ (i.e. not this library) is responsible for tracking latency of events consumed from the stream.  Because of the way it is implemented in the apps, if an event gets stuck (e.g. cannot be written to destination) then the latency drops to zero for the period when the app is retrying the stuck event.

This commit aims to fix the problem where the `latency_millis` metric wrongly drops to zero.

1. The source itself now tracks the latency of the event which is currently being processed by the downstream application.
2. The Metrics class allows metric starting values to be wrapped in and Effect, i.e. `F[Metrics.State]`. This means the application can pass in the latency reported by the Source.