### PR TITLE
Sink configs should allow for optional sinks

### DIFF
--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
@@ -7,6 +7,7 @@
  */
 package com.snowplowanalytics.snowplow.it.kinesis
 
+import cats.Id
 import cats.effect.{IO, Ref}
 
 import scala.jdk.CollectionConverters._
@@ -19,7 +20,7 @@ import software.amazon.awssdk.services.kinesis.model.{GetRecordsRequest, GetShar
 import com.snowplowanalytics.snowplow.sources.{EventProcessor, TokenedEvents}
 import com.snowplowanalytics.snowplow.sources.kinesis.KinesisSourceConfig
 import com.snowplowanalytics.snowplow.kinesis.BackoffPolicy
-import com.snowplowanalytics.snowplow.sinks.kinesis.KinesisSinkConfig
+import com.snowplowanalytics.snowplow.sinks.kinesis.{KinesisSinkConfig, KinesisSinkConfigM}
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -99,7 +100,7 @@ object Utils {
     10.seconds
   )
 
-  def getKinesisSinkConfig(endpoint: URI)(streamName: String): KinesisSinkConfig = KinesisSinkConfig(
+  def getKinesisSinkConfig(endpoint: URI)(streamName: String): KinesisSinkConfig = KinesisSinkConfigM[Id](
     streamName,
     BackoffPolicy(1.second, 1.second),
     1000,

--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sinks/kafka/KafkaSinkConfig.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sinks/kafka/KafkaSinkConfig.scala
@@ -7,15 +7,25 @@
  */
 package com.snowplowanalytics.snowplow.sinks.kafka
 
+import cats.Id
 import io.circe.Decoder
 import io.circe.generic.semiauto._
 
-case class KafkaSinkConfig(
-  topicName: String,
-  bootstrapServers: String,
+case class KafkaSinkConfigM[M[_]](
+  topicName: M[String],
+  bootstrapServers: M[String],
   producerConf: Map[String, String]
 )
 
-object KafkaSinkConfig {
+object KafkaSinkConfigM {
   implicit def decoder: Decoder[KafkaSinkConfig] = deriveDecoder[KafkaSinkConfig]
+
+  implicit def optionalDecoder: Decoder[Option[KafkaSinkConfig]] =
+    deriveDecoder[KafkaSinkConfigM[Option]].map {
+      case KafkaSinkConfigM(Some(t), Some(b), conf) =>
+        Some(KafkaSinkConfigM[Id](t, b, conf))
+      case _ =>
+        None
+    }
+
 }

--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sinks
+
+import cats.Id
+
+package object kafka {
+
+  type KafkaSinkConfig = KafkaSinkConfigM[Id]
+}

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/sinks/kafka/KafkaSinkConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/sinks/kafka/KafkaSinkConfigSpec.scala
@@ -7,6 +7,7 @@
  */
 package com.snowplowanalytics.snowplow.sinks.kafka
 
+import cats.Id
 import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import io.circe.config.syntax.CirceConfigOps
@@ -40,7 +41,7 @@ class KafkaSinkConfigSpec extends Specification {
 
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
-    val expected = KafkaSinkConfig(
+    val expected = KafkaSinkConfigM[Id](
       topicName        = "my-topic",
       bootstrapServers = "my-bootstrap-server:9092",
       producerConf = Map(

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sinks
+
+import cats.Id
+
+package object kinesis {
+  type KinesisSinkConfig = KinesisSinkConfigM[Id]
+}

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSinkConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/sinks/kinesis/KinesisSinkConfigSpec.scala
@@ -38,7 +38,7 @@ class KinesisSinkConfigSpec extends Specification {
 
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
-    val expected = KinesisSinkConfig(
+    val expected = KinesisSinkConfigM(
       streamName             = "my-stream",
       throttledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
       recordLimit            = 500,

--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/sinks/nsq/NsqSinkConfig.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/sinks/nsq/NsqSinkConfig.scala
@@ -9,18 +9,27 @@ package com.snowplowanalytics.snowplow.sinks.nsq
 
 import io.circe._
 import io.circe.generic.semiauto._
+import cats.Id
 
 import com.snowplowanalytics.snowplow.nsq.BackoffPolicy
 
-case class NsqSinkConfig(
-  topic: String,
-  nsqdHost: String,
-  nsqdPort: Int,
+case class NsqSinkConfigM[M[_]](
+  topic: M[String],
+  nsqdHost: M[String],
+  nsqdPort: M[Int],
   byteLimit: Int,
   backoffPolicy: BackoffPolicy
 )
 
-object NsqSinkConfig {
+object NsqSinkConfigM {
   implicit def decoder: Decoder[NsqSinkConfig] =
     deriveDecoder[NsqSinkConfig]
+
+  implicit def optionalDecoder: Decoder[Option[NsqSinkConfig]] =
+    deriveDecoder[NsqSinkConfigM[Option]].map {
+      case NsqSinkConfigM(Some(t), Some(h), Some(p), byteLimit, conf) =>
+        Some(NsqSinkConfigM[Id](t, h, p, byteLimit, conf))
+      case _ =>
+        None
+    }
 }

--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sinks
+
+import cats.Id
+
+package object nsq {
+
+  type NsqSinkConfig = NsqSinkConfigM[Id]
+}

--- a/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/sinks/nsq/NsqSinkConfigSpec.scala
+++ b/modules/nsq/src/test/scala/com/snowplowanalytics/snowplow/sinks/nsq/NsqSinkConfigSpec.scala
@@ -9,6 +9,7 @@ package com.snowplowanalytics.snowplow.sinks.nsq
 
 import com.typesafe.config.ConfigFactory
 
+import cats.Id
 import io.circe.config.syntax.CirceConfigOps
 import io.circe.Decoder
 import io.circe.generic.semiauto._
@@ -41,7 +42,7 @@ class NsqSinkConfigSpec extends Specification {
 
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
-    val expected = NsqSinkConfig(
+    val expected = NsqSinkConfigM[Id](
       topic         = "test-topic",
       nsqdHost      = "127.0.0.1",
       nsqdPort      = 4150,

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/sinks/package.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.sinks
+
+import cats.Id
+
+package object pubsub {
+
+  type PubsubSinkConfig = PubsubSinkConfigM[Id]
+
+}

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sinks/pubsub/PubsubSinkConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/sinks/pubsub/PubsubSinkConfigSpec.scala
@@ -7,6 +7,7 @@
  */
 package com.snowplowanalytics.snowplow.sinks.pubsub
 
+import cats.Id
 import com.typesafe.config.ConfigFactory
 import io.circe.config.syntax.CirceConfigOps
 import io.circe.Decoder
@@ -38,7 +39,7 @@ class PubsubSinkConfigSpec extends Specification {
 
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
-    val expected = PubsubSinkConfig(
+    val expected = PubsubSinkConfigM[Id](
       topic                = PubsubSinkConfig.Topic("my-project", "my-topic"),
       batchSize            = 1000L,
       requestByteThreshold = 1000000L,


### PR DESCRIPTION
In Enrich, the failed sink is optional. But it is convenient to provide defaults in the reference.conf file for some of the sink's fields.

This commit re-defines the sink configs, and provides a JSON decoder for an optional sink.