### PR TITLE
Add group.instance.id to kafka consumer config

### DIFF
--- a/modules/kafka/src/main/resources/reference.conf
+++ b/modules/kafka/src/main/resources/reference.conf
@@ -2,7 +2,8 @@ snowplow.defaults {
   sources: {
     kafka: {
       consumerConf: {
-        "group.id": null # invalid value MUST be overridden by the applicaion
+        "group.id": null # invalid value MUST be overridden by the application
+        "group.instance.id": ${?HOSTNAME}
         "allow.auto.create.topics": "false"
         "auto.offset.reset": "latest"
         "security.protocol": "SASL_SSL"
@@ -16,7 +17,7 @@ snowplow.defaults {
   sinks: {
     kafka: {
       producerConf: {
-        "client.id": null # invalid value MUST be overriden by the application
+        "client.id": null # invalid value MUST be overridden by the application
         "security.protocol": "SASL_SSL"
         "sasl.mechanism": "OAUTHBEARER"
         "sasl.jaas.config": "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;"

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/sources/kafka/KafkaSourceConfigSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/sources/kafka/KafkaSourceConfigSpec.scala
@@ -47,6 +47,7 @@ class KafkaSourceConfigSpec extends Specification {
       bootstrapServers = "my-bootstrap-server:9092",
       consumerConf = Map(
         "group.id" -> "my-consumer-group",
+        "group.instance.id" -> System.getenv("HOSTNAME"),
         "allow.auto.create.topics" -> "false",
         "auto.offset.reset" -> "latest",
         "security.protocol" -> "SASL_SSL",


### PR DESCRIPTION
This PR adds `group.instance.id` to default kafka consumer configuration, changing our kafka consumers' membership from dynamic to static to prevent partition rebalancing happening during pod crash/restarts.

Note that we don't set `session.timeout.ms` explicitly and rely on the current default value of `45 seconds`. The reason of not picking a longer session timeout comes from horizontal scaling. A long, e.g. 3 minutes, session timeout means that the partition assigned to an evicted pod won't be processed for 3 minutes until broker recognize it. We want broker to be aware of evicted pods as soon as possible & prevent broker from triggering a partition rebalance in case of pod restarts at the same time.

ref: [PDP-1797](https://snplow.atlassian.net/browse/PDP-1797)

[PDP-1797]: https://snplow.atlassian.net/browse/PDP-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ