### PR TITLE
Pubsub Source/Sink to work with emulator for local developent

### DIFF
--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactory.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactory.scala
@@ -9,10 +9,10 @@ package com.snowplowanalytics.snowplow.streams.pubsub
 
 import cats.implicits._
 import cats.effect.{Async, Resource, Sync}
+import io.grpc.ManagedChannelBuilder
 import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
-import com.google.api.gax.core.FixedExecutorProvider
-import com.google.api.gax.grpc.ChannelPoolSettings
-import com.google.auth.Credentials
+import com.google.api.gax.core.{CredentialsProvider, FixedCredentialsProvider, FixedExecutorProvider, NoCredentialsProvider}
+import com.google.api.gax.grpc.{ChannelPoolSettings, GrpcTransportChannel}
 import com.google.cloud.pubsub.v1.{SubscriptionAdminSettings, TopicAdminSettings}
 import org.threeten.bp.{Duration => ThreetenDuration}
 
@@ -24,14 +24,15 @@ import java.util.concurrent.{Executors, ScheduledExecutorService}
 
 class PubsubFactory[F[_]: Async] private (
   transport: FixedTransportChannelProvider,
-  executor: FixedExecutorProvider
+  executor: FixedExecutorProvider,
+  credentials: CredentialsProvider
 ) extends Factory[F, PubsubSourceConfig, PubsubSinkConfig] {
 
   def sink(config: PubsubSinkConfig): Resource[F, Sink[F]] =
-    PubsubSink.resource(config, transport, executor)
+    PubsubSink.resource(config, transport, executor, credentials)
 
   def source(config: PubsubSourceConfig): Resource[F, SourceAndAck[F]] =
-    PubsubSource.resource(config, transport, executor)
+    PubsubSource.resource(config, transport, executor, credentials)
 }
 
 object PubsubFactory {
@@ -39,11 +40,48 @@ object PubsubFactory {
   def resource[F[_]: Async](config: PubsubFactoryConfig): Resource[F, PubsubFactory[F]] =
     for {
       executor <- executorResource[F]
-      channel <- makeChannel(config.gcpUserAgent, executor)
-    } yield new PubsubFactory(FixedTransportChannelProvider.create(channel), FixedExecutorProvider.create(executor))
+      credentialsProvider <- Resource.eval(makeCredentialsProvider[F](config))
+      channel <- makeChannel(config, executor)
+    } yield new PubsubFactory(FixedTransportChannelProvider.create(channel), FixedExecutorProvider.create(executor), credentialsProvider)
 
-  def makeChannel[F[_]: Sync](gcpUserAgent: GcpUserAgent, executor: ScheduledExecutorService): Resource[F, TransportChannel] = {
-    def withCredentials(credentials: Credentials) = Sync[F].delay {
+  def makeCredentialsProvider[F[_]: Sync](config: PubsubFactoryConfig): F[CredentialsProvider] =
+    config.emulatorHost match {
+      case Some(_) =>
+        // The pubsub emulator is enabled, so do not try to resolve credentials
+        Sync[F].pure(NoCredentialsProvider.create())
+      case None =>
+        // Pubsub emulator _not_ enabled. Use real credentials for real pubsub
+        Sync[F]
+          .blocking(TopicAdminSettings.defaultCredentialsProviderBuilder().build().getCredentials())
+          .map(FixedCredentialsProvider.create(_))
+    }
+
+  private def makeChannel[F[_]: Sync](config: PubsubFactoryConfig, executor: ScheduledExecutorService): Resource[F, TransportChannel] =
+    config.emulatorHost match {
+      case Some(emulatorHost) => makeEmulatorChannel(emulatorHost)
+      case None               => makeProductionChannel(config.gcpUserAgent, executor)
+    }
+
+  /**
+   * Makes a `TransportChannel` for when using the pubsub emulator for local development
+   */
+  private def makeEmulatorChannel[F[_]: Sync](emulatorHost: String): Resource[F, TransportChannel] = {
+    val make = Sync[F].delay {
+      ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build()
+    }
+    Resource
+      .make(make)(chan => Sync[F].blocking(chan.shutdown()).void)
+      .map(GrpcTransportChannel.create(_))
+  }
+
+  /**
+   * Makes a `TransportChannel` for when _not_ using the pubsub emulator, i.e. the "real" pubsub
+   */
+  private def makeProductionChannel[F[_]: Sync](
+    gcpUserAgent: GcpUserAgent,
+    executor: ScheduledExecutorService
+  ): Resource[F, TransportChannel] = {
+    val makeProvider = Sync[F].delay {
       SubscriptionAdminSettings
         .defaultGrpcTransportProviderBuilder()
         .setMaxInboundMessageSize(20 << 20) // 20 MB
@@ -54,14 +92,12 @@ object PubsubFactory {
         }
         .setEndpoint(SubscriptionAdminSettings.getDefaultEndpoint())
         .setHeaderProvider(GcpUserAgent.headerProvider(gcpUserAgent))
-        .setCredentials(credentials)
         .setExecutor(executor)
         .build
     }
 
     val make = for {
-      credentials <- Sync[F].blocking(TopicAdminSettings.defaultCredentialsProviderBuilder().build().getCredentials())
-      provider <- withCredentials(credentials)
+      provider <- makeProvider
       channel <- Sync[F].blocking(provider.getTransportChannel)
     } yield channel
 

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactoryConfig.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactoryConfig.scala
@@ -12,9 +12,15 @@ import io.circe.generic.semiauto._
 
 /**
  * Configures the Pubsub Factory
+ *
+ * @param gcpUserAgent
+ *   configures the user-agent header in requests to pubsub
+ * @param emulatorHost
+ *   Optional, e.g. `localhost:8181`. Use the pubsub emulator for local development.
  */
 case class PubsubFactoryConfig(
-  gcpUserAgent: GcpUserAgent
+  gcpUserAgent: GcpUserAgent,
+  emulatorHost: Option[String]
 )
 
 object PubsubFactoryConfig {

--- a/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactoryConfigSpec.scala
+++ b/modules/pubsub/src/test/scala/com/snowplowanalytics/snowplow/streams/pubsub/PubsubFactoryConfigSpec.scala
@@ -36,7 +36,8 @@ class PubsubFactoryConfigSpec extends Specification {
     val result = ConfigFactory.load(ConfigFactory.parseString(input))
 
     val expected = PubsubFactoryConfig(
-      gcpUserAgent = GcpUserAgent("Snowplow OSS", "example-version")
+      gcpUserAgent = GcpUserAgent("Snowplow OSS", "example-version"),
+      emulatorHost = None
     )
 
     result.as[Wrapper] must beRight.like { case w: Wrapper =>


### PR DESCRIPTION
Refers to the pubsub emulator documented here: https://cloud.google.com/pubsub/docs/emulator

We want to start using the common-streams pubsub sink for the snowplow collector.  The collector has [existing integration tests using the pubsub emulator](https://github.com/snowplow/stream-collector/blob/3.4.0/pubsub/src/it/scala/com/snowplowanalytics/snowplow/collectors/scalastream/it/pubsub/Containers.scala#L33-L47), so it would be nice to retain these when we start using comon-streams.