### PR TITLE
Add new method `isHealthy` to sinks

### DIFF
--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
@@ -7,10 +7,13 @@
  */
 package com.snowplowanalytics.snowplow.streams.kafka.sink
 
+import cats.implicits._
 import cats.effect.{Async, Resource, Sync}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import com.snowplowanalytics.snowplow.streams.{ListOfList, Sink, Sinkable}
 import com.snowplowanalytics.snowplow.streams.kafka.KafkaSinkConfig
@@ -31,6 +34,8 @@ private[kafka] object KafkaSink {
       producer <- makeProducer(config, authHandlerClass)
       ec <- createExecutionContext
     } yield impl(config, producer, ec)
+
+  private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
 
   private def makeProducer[F[_]: Async](
     config: KafkaSinkConfig,
@@ -66,10 +71,20 @@ private[kafka] object KafkaSink {
         Async[F].evalOn(f, ec)
       }
 
-      def pingForHealth: F[Boolean] =
-        Sync[F].blocking {
-          producer.partitionsFor(config.topicName).asScala.nonEmpty
-        }
+      def isHealthy: F[Boolean] =
+        Logger[F].info(s"Checking whether topic ${config.topicName} has leaders for all partitions") >>
+          Sync[F]
+            .blocking {
+              producer.partitionsFor(config.topicName).asScala
+            }
+            .flatMap { partitions =>
+              if (partitions.isEmpty)
+                Logger[F].warn(s"Topic ${config.topicName} has no partitions").as(false)
+              else if (partitions.exists(p => Option(p.leader()).isEmpty))
+                Logger[F].warn(s"Topic ${config.topicName} has partitions with no leader").as(false)
+              else
+                Logger[F].info(s"Confirmed topic ${config.topicName} has leaders for all partitions").as(true)
+            }
     }
 
   private def toProducerRecord(config: KafkaSinkConfig, sinkable: Sinkable): ProducerRecord[String, Array[Byte]] = {

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/sink/KinesisSink.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/sink/KinesisSink.scala
@@ -51,7 +51,7 @@ private[kinesis] object KinesisSink {
             batch
           )
 
-        def pingForHealth: F[Boolean] =
+        def isHealthy: F[Boolean] =
           checkShardsAreOpen(config.streamName, p)
       }
     }

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/sink/KinesisSink.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/sink/KinesisSink.scala
@@ -19,7 +19,14 @@ import software.amazon.awssdk.core.SdkBytes
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.awssdk.awscore.defaultsmode.DefaultsMode
-import software.amazon.awssdk.services.kinesis.model.{PutRecordsRequest, PutRecordsRequestEntry, PutRecordsResponse}
+import software.amazon.awssdk.services.kinesis.model.{
+  ListShardsRequest,
+  PutRecordsRequest,
+  PutRecordsRequestEntry,
+  PutRecordsResponse,
+  ShardFilter,
+  ShardFilterType
+}
 
 import com.snowplowanalytics.snowplow.streams.kinesis.{BackoffPolicy, KinesisSinkConfig, Retries}
 
@@ -34,15 +41,19 @@ private[kinesis] object KinesisSink {
 
   def resource[F[_]: Async](config: KinesisSinkConfig, client: SdkAsyncHttpClient): Resource[F, Sink[F]] =
     mkProducer[F](config, client).map { p =>
-      Sink(
-        writeToKinesis[F](
-          config.throttledBackoffPolicy,
-          RequestLimits(config.recordLimit, config.byteLimit),
-          p,
-          config.streamName,
-          _
-        )
-      )
+      new Sink[F] {
+        def sink(batch: ListOfList[Sinkable]): F[Unit] =
+          writeToKinesis[F](
+            config.throttledBackoffPolicy,
+            RequestLimits(config.recordLimit, config.byteLimit),
+            p,
+            config.streamName,
+            batch
+          )
+
+        def pingForHealth: F[Boolean] =
+          checkShardsAreOpen(config.streamName, p)
+      }
     }
 
   private implicit def logger[F[_]: Sync]: SelfAwareStructuredLogger[F] = Slf4jLogger.getLogger[F]
@@ -57,6 +68,37 @@ private[kinesis] object KinesisSink {
         builder.build()
       }
     }
+
+  private def checkShardsAreOpen[F[_]: Async](streamName: String, client: KinesisAsyncClient): F[Boolean] = {
+    def go(nextToken: Option[String]): F[Boolean] =
+      Async[F]
+        .fromCompletableFuture {
+          Sync[F].delay {
+            val request = ListShardsRequest.builder
+              .streamName(streamName)
+              .shardFilter {
+                ShardFilter.builder.`type`(ShardFilterType.AT_LATEST).build
+              }
+              .nextToken(nextToken.orNull)
+              .build
+            client.listShards(request)
+          }
+        }
+        .flatMap { response =>
+          if (response.hasShards)
+            Logger[F].info(s"Confirmed stream $streamName has open shards").as(true)
+          else {
+            Option(response.nextToken) match {
+              case Some(t) =>
+                go(Some(t))
+              case None =>
+                Logger[F].warn(s"Stream $streamName has no open shards").as(false)
+            }
+          }
+        }
+
+    Logger[F].info(s"Checking whether stream $streamName has open shards") >> go(None)
+  }
 
   private def toKinesisRecords(records: ListOfList[Sinkable]): ListOfList[PutRecordsRequestEntry] =
     records.mapUnordered { r =>

--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/streams/nsq/sink/NsqSink.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/streams/nsq/sink/NsqSink.scala
@@ -32,7 +32,7 @@ private[nsq] object NsqSink {
         def sink(batch: ListOfList[Sinkable]): F[Unit] =
           sinkBatch[F](p, config, batch)
 
-        def pingForHealth: F[Boolean] =
+        def isHealthy: F[Boolean] =
           Sync[F].pure(true)
       }
     }

--- a/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/sink/PubsubSink.scala
+++ b/modules/pubsub/src/main/scala/com/snowplowanalytics/snowplow/streams/pubsub/sink/PubsubSink.scala
@@ -41,7 +41,7 @@ private[pubsub] object PubsubSink {
         def sink(batch: ListOfList[Sinkable]): F[Unit] =
           sinkBatch[F](config, stub, batch)
 
-        def pingForHealth: F[Boolean] =
+        def isHealthy: F[Boolean] =
           topicExists(config, stub)
       }
     }

--- a/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/streams/Sink.scala
+++ b/modules/streams-core/src/main/scala/com.snowplowanalytics.snowplow/streams/Sink.scala
@@ -26,18 +26,21 @@ trait Sink[F[_]] {
   /**
    * Ping the external resource to check it is healthy and ready to receive events
    *
-   * The sink is expected to actively ping the external resource, e.g. by sending a HTTP request.
+   * The sink is expected to probe the external resource just one time, e.g. by sending a HTTP
+   * request, and then return a result
    *
    * This health check can yield any of three results:
    *
-   *   1. `true` (wrapped in `F`). This is the only result that indicates the sink is healthy. 2.
-   *      `false` (wrapped in `F`). This means we successfully probed the external resource, but it
-   *      tells us the external resource is not ready to receive messages. 3. An exception raised
-   *      via the `F`.
+   *   1. `true` (wrapped in `F`). This is the only result that indicates the sink is healthy.
    *
-   * An application calling `pingForHealth` should check for all types of result: true / false /
+   * 2. `false` (wrapped in `F`). This means we successfully probed the external resource, but it
+   * tells us the external resource is not ready to receive messages.
+   *
+   * 3. An exception raised via the `F`.
+   *
+   * An application calling `isHealthy` should check for all types of result: true / false /
    * exception
    */
-  def pingForHealth: F[Boolean]
+  def isHealthy: F[Boolean]
 
 }


### PR DESCRIPTION
We want to start using the common-streams sinks in the snowplow collector. Until now, common-streams only discovers a sink is unavailable if it fails to send events to the sink. But the collector has a requirement that it needs to know the health of the sink immediately upon startup, see snowplow/stream-collector#276

This commit adds a new method `isHealthy` to the `Sink` trait. Implementations of `Sink` should probe the external resource to check its health.