### PR TITLE
Define sink factory types for easier imports in apps

### DIFF
--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/package.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/package.scala
@@ -11,5 +11,6 @@ import cats.Id
 
 package object kafka {
 
-  type KafkaSinkConfig = KafkaSinkConfigM[Id]
+  type KafkaSinkConfig    = KafkaSinkConfigM[Id]
+  type KafkaFactory[F[_]] = Factory[F, KafkaSourceConfig, KafkaSinkConfig]
 }

--- a/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/streams/nsq/package.scala
+++ b/modules/nsq/src/main/scala/com/snowplowanalytics/snowplow/streams/nsq/package.scala
@@ -11,5 +11,6 @@ import cats.Id
 
 package object nsq {
 
-  type NsqSinkConfig = NsqSinkConfigM[Id]
+  type NsqSinkConfig    = NsqSinkConfigM[Id]
+  type NsqFactory[F[_]] = Factory[F, NsqSourceConfig, NsqSinkConfig]
 }


### PR DESCRIPTION
This amends the feature added in #122.  When I came to use the factories in an app, I found the syntax is cumbersome, because the factory's type is `Factory[F, KafkaSourceConfigM[Id], KafkaSinkConfig]`.  This PR just defines a shorthand for the type, so in the app I can pass it around with the simple type `KafkaFactory[F]`.