### PR TITLE
Reduce default maxRecordSize of Pubsub sink to 9 MB

### DIFF
--- a/modules/pubsub/src/main/resources/reference.conf
+++ b/modules/pubsub/src/main/resources/reference.conf
@@ -13,7 +13,8 @@ snowplow.defaults: {
     pubsub: {
       batchSize: 1000
       requestByteThreshold: 1000000
-      maxRecordSize: 10000000
+      # Equal to 9 MB. Pubsub message size limit 10 MB however, we further reduce it to 9 MB to be on the safe side.
+      maxRecordSize: 9000000
     }
   }
 


### PR DESCRIPTION
Default maxRecordSize of Pubsub sink is reduced to make Pubsub sink safer. 