### PR TITLE
Bump sbt-ci-release to 1.11.1

### DIFF
--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSinkConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSinkConfigSpec.scala
@@ -7,7 +7,6 @@
  */
 package com.snowplowanalytics.snowplow.streams.kinesis
 
-import io.circe.literal._
 import com.typesafe.config.ConfigFactory
 import io.circe.config.syntax.CirceConfigOps
 import io.circe.Decoder

--- a/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/TelemetryConfigSpec.scala
+++ b/modules/runtime-common/src/test/scala/com/snowplowanalytics/snowplow/runtime/TelemetryConfigSpec.scala
@@ -7,11 +7,9 @@
  */
 package com.snowplowanalytics.snowplow.runtime
 
-import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import io.circe.config.syntax.CirceConfigOps
 import io.circe.Decoder
-import io.circe.literal._
 import io.circe.generic.semiauto._
 import org.http4s.implicits._
 import org.specs2.Specification

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -34,7 +34,7 @@ import com.snowplowanalytics.snowplow.sbt.IgluSchemaPlugin.autoImport._
 object BuildSettings {
 
   lazy val scala212 = "2.12.18"
-  lazy val scala213 = "2.13.12"
+  lazy val scala213 = "2.13.15"
 
   lazy val buildSettings = Seq(
     organization := "com.snowplowanalytics",
@@ -42,8 +42,7 @@ object BuildSettings {
     crossScalaVersions := List(scala212, scala213),
     scalafmtConfig := file(".scalafmt.conf"),
     scalafmtOnCompile := false,
-    scalacOptions += "-Ywarn-macros:after",
-    scalacOptions += "-Wconf:origin=scala.collection.compat.*:s",
+    scalacOptions ++= scalacOptionsVersion(scalaVersion.value),
     Test / fork := true,
     Test / envVars := Map(
       "CONFIG_PARSER_TEST_ENV" -> "envValue",
@@ -63,6 +62,17 @@ object BuildSettings {
       Seq(license)
     }.taskValue
   )
+
+  def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
+    // Scala 2.12 needs -Ywarn-macros:after to match the default compiler behaviour of scala 2.13.
+    val versionSpecificOptions = CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor)) if scalaMajor == 12 => Seq("-Ywarn-macros:after")
+      case _                                         => Nil
+    }
+    Seq(
+      "-Wconf:origin=scala.collection.compat.*:s"
+    ) ++ versionSpecificOptions
+  }
 
   lazy val publishSettings = Seq[Setting[_]](
     publishArtifact := true,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val circeExtra       = "0.14.4"
     val circeConfig      = "0.10.1"
     val betterMonadicFor = "0.3.1"
-    val kindProjector    = "0.13.2"
+    val kindProjector    = "0.13.3"
     val collectionCompat = "2.11.0"
 
     // Streams

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.typelevel"         % "sbt-tpolecat"         % "0.5.0")
 addSbtPlugin("org.scalameta"         % "sbt-scalafmt"         % "2.5.2")
 addSbtPlugin("com.snowplowanalytics" % "sbt-snowplow-release" % "0.3.1")
 addSbtPlugin("com.eed3si9n"          % "sbt-buildinfo"        % "0.11.0")
-addSbtPlugin("com.github.sbt"        % "sbt-ci-release"       % "1.5.12")
+addSbtPlugin("com.github.sbt"        % "sbt-ci-release"       % "1.11.1")
 addSbtPlugin("com.typesafe"          % "sbt-mima-plugin"      % "1.1.3")
 addSbtPlugin("com.github.sbt"        % "sbt-site"             % "1.5.0")
 addSbtPlugin(


### PR DESCRIPTION
Jira ref: [PDP-2000](https://snplow.atlassian.net/browse/PDP-2000)

Due to [sunset of OSSRH](https://central.sonatype.org/pages/ossrh-eol/), we need to start to publish to [Maven Central Portal](https://central.sonatype.com/). To be able to do that, we need to bump sbt-ci-release plugin to >= [1.11.0](https://github.com/sbt/sbt-ci-release/releases/tag/v1.11.0)

Upgrading sbt-ci-release plugin requires upgrading sbt to >= `1.11.0` as well and upgrading sbt requires upgrading Scala 2.13.x version to `2.13.15`.

[PDP-2000]: https://snplow.atlassian.net/browse/PDP-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ