### PR TITLE
Clean shutdown logs of kinesis source

### DIFF
--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/source/KCLScheduler.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/source/KCLScheduler.scala
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient
 import software.amazon.kinesis.common.{ConfigsBuilder, InitialPositionInStream, InitialPositionInStreamExtended}
 import software.amazon.kinesis.coordinator.{Scheduler, WorkerStateChangeListener}
-import software.amazon.kinesis.metrics.MetricsLevel
+import software.amazon.kinesis.metrics.NullMetricsFactory
 import software.amazon.kinesis.processor.SingleStreamTracker
 import software.amazon.kinesis.retrieval.fanout.FanOutConfig
 import software.amazon.kinesis.retrieval.polling.PollingConfig
@@ -99,7 +99,7 @@ private[source] object KCLScheduler {
         coordinatorConfig,
         leaseManagementConfig,
         configsBuilder.lifecycleConfig,
-        configsBuilder.metricsConfig.metricsLevel(MetricsLevel.NONE),
+        configsBuilder.metricsConfig.metricsFactory(new NullMetricsFactory),
         processorConfig,
         retrievalConfig
       )


### PR DESCRIPTION
Jira ref: [PDP-2176](https://snplow.atlassian.net/browse/PDP-2176)

1. Catches `InterruptedException` caused by KCL's shutdown
2. Uses a `NullMetricsFactory` to disable cloudwatch metrics

Both of these changes lead to fewer noisy unhelpful log lines during shutdown

[PDP-2176]: https://snplow.atlassian.net/browse/PDP-2176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ