### PR TITLE
Kafka Soruce change from async to sync for committing offsets

### DIFF
--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaFactory.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaFactory.scala
@@ -30,12 +30,10 @@ object KafkaFactory {
         } yield result
 
       def source(config: KafkaSourceConfig): Resource[F, SourceAndAck[F]] =
-        Resource.eval {
-          for {
-            cbHandler <- acquireCallbackHandler(callbackHandlers)
-            result <- KafkaSource.build(config, cbHandler)
-          } yield result
-        }
+        for {
+          cbHandler <- Resource.eval(acquireCallbackHandler(callbackHandlers))
+          result <- KafkaSource.build(config, cbHandler)
+        } yield result
     }
 
   private def acquireCallbackHandler[F[_]: Sync](callbackHandlers: Ref[F, List[String]]): F[String] =


### PR DESCRIPTION
Previously we used `CommittableOffset.commit` provided by fs2-kafka. Underneath, this calls `KafkaConsumer.commitAsync` provided by the Kafka consumer library.

This commit changes to explicitly calling `KafkaConsumer.commitSync`.

An important difference between `commitAsync` and `commitSync` is the latter keeps retrying the commit until successful. This change should decrease the number of exceptions raised to the application due to failure to commit an offset.