### PR TITLE
Add AWS user-agent

### DIFF
--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSinkSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSinkSpec.scala
@@ -20,7 +20,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 import software.amazon.awssdk.regions.Region
 
 import com.snowplowanalytics.snowplow.streams.{ListOfList, Sink, Sinkable}
-import com.snowplowanalytics.snowplow.streams.kinesis.KinesisFactory
+import com.snowplowanalytics.snowplow.streams.kinesis.{KinesisFactory, KinesisFactoryConfig}
 
 import Utils._
 import org.specs2.specification.BeforeAll
@@ -39,7 +39,7 @@ class KinesisSinkSpec extends CatsResource[IO, (Region, LocalStackContainer, Sin
     for {
       region <- Resource.eval(IO.blocking((new DefaultAwsRegionProviderChain).getRegion))
       localstack <- Localstack.resource(region, KINESIS_INITIALIZE_STREAMS, KinesisSinkSpec.getClass.getSimpleName)
-      testFactory <- KinesisFactory.resource[IO]
+      testFactory <- KinesisFactory.resource[IO](KinesisFactoryConfig(awsUserAgent = None))
       testSink <- testFactory.sink(getKinesisSinkConfig(localstack.getEndpoint)(testStream1Name))
     } yield (region, localstack, testSink)
 

--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceSpec.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/KinesisSourceSpec.scala
@@ -22,7 +22,7 @@ import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 
 import com.snowplowanalytics.snowplow.streams.EventProcessingConfig
 import com.snowplowanalytics.snowplow.streams.EventProcessingConfig.NoWindowing
-import com.snowplowanalytics.snowplow.streams.kinesis.{KinesisFactory, KinesisSourceConfig}
+import com.snowplowanalytics.snowplow.streams.kinesis.{KinesisFactory, KinesisFactoryConfig, KinesisSourceConfig}
 
 import Utils._
 
@@ -46,7 +46,7 @@ class KinesisSourceSpec
       region <- Resource.eval(IO.blocking((new DefaultAwsRegionProviderChain).getRegion))
       localstack <- Localstack.resource(region, KINESIS_INITIALIZE_STREAMS, KinesisSourceSpec.getClass.getSimpleName)
       kinesisClient <- Resource.eval(getKinesisClient(localstack.getEndpoint, region))
-      kinesisFactory <- KinesisFactory.resource[IO]
+      kinesisFactory <- KinesisFactory.resource[IO](KinesisFactoryConfig(awsUserAgent = None))
     } yield (localstack, kinesisClient, getKinesisSourceConfig(localstack.getEndpoint)(_), kinesisFactory)
 
   override def is = s2"""

--- a/modules/kinesis/src/main/resources/reference.conf
+++ b/modules/kinesis/src/main/resources/reference.conf
@@ -1,4 +1,12 @@
 snowplow.defaults: {
+  factories: {
+    kinesis: {
+      # Optional AWS user-agent string for tracking cloud spend attribution
+      # No default value for open-source
+      # awsUserAgent: "MyApp/1.0"
+    }
+  }
+
   sources: {
     kinesis: {
       workerIdentifier: ${?HOSTNAME}

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisFactoryConfig.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisFactoryConfig.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.streams.kinesis
+
+import io.circe._
+import io.circe.generic.semiauto._
+
+/**
+ * Configuration for the Kinesis factory
+ *
+ * @param awsUserAgent
+ *   Optional custom user-agent string for AWS SDK calls
+ */
+case class KinesisFactoryConfig(
+  awsUserAgent: Option[String]
+)
+
+object KinesisFactoryConfig {
+  implicit def decoder: Decoder[KinesisFactoryConfig] = deriveDecoder[KinesisFactoryConfig]
+}

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisFactoryConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisFactoryConfigSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.streams.kinesis
+
+import com.typesafe.config.ConfigFactory
+import io.circe.config.syntax.CirceConfigOps
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+import org.specs2.Specification
+
+class KinesisFactoryConfigSpec extends Specification {
+  import KinesisFactoryConfigSpec._
+
+  def is = s2"""
+  The KinesisFactory config should:
+    Parse with no user-agent $e1
+    Parse with custom user-agent $e2
+  """
+
+  def e1 = {
+    val input = s"""
+    |{
+    |   "xyz": {}
+    |}
+    |""".stripMargin
+
+    val result = ConfigFactory.load(ConfigFactory.parseString(input))
+
+    val expected = KinesisFactoryConfig(
+      awsUserAgent = None
+    )
+
+    result.as[Wrapper] must beRight.like { case w: Wrapper =>
+      w.xyz must beEqualTo(expected)
+    }
+  }
+
+  def e2 = {
+    val input = s"""
+    |{
+    |   "xyz": {
+    |     "awsUserAgent": "MyApp/1.0.0"
+    |   }
+    |}
+    |""".stripMargin
+
+    val result = ConfigFactory.load(ConfigFactory.parseString(input))
+
+    val expected = KinesisFactoryConfig(
+      awsUserAgent = Some("MyApp/1.0.0")
+    )
+
+    result.as[Wrapper] must beRight.like { case w: Wrapper =>
+      w.xyz must beEqualTo(expected)
+    }
+  }
+
+}
+
+object KinesisFactoryConfigSpec {
+  case class Wrapper(xyz: KinesisFactoryConfig)
+
+  implicit def wrapperDecoder: Decoder[Wrapper] = deriveDecoder[Wrapper]
+}


### PR DESCRIPTION
Add support to set custom user-agent on all AWS SDK clients (Kinesis, DynamoDB, CloudWatch) to enable tracking of customer cloud spend via Snowplow.

ref: https://snplow.atlassian.net/browse/PDP-2241