### PR TITLE
Add configurable AWS SDK retry count for Kinesis source

### DIFF
--- a/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
+++ b/modules/it/src/test/scala/com/snowplowanalytics/snowplow/sources/kinesis/Utils.scala
@@ -95,7 +95,8 @@ object Utils {
     10.seconds,
     BigDecimal(1.0),
     BackoffPolicy(100.millis, 1.second),
-    10.seconds
+    10.seconds,
+    10
   )
 
   def getKinesisSinkConfig(endpoint: URI)(streamName: String): KinesisSinkConfig = KinesisSinkConfigM[Id](

--- a/modules/kinesis/src/main/resources/reference.conf
+++ b/modules/kinesis/src/main/resources/reference.conf
@@ -16,6 +16,7 @@ snowplow.defaults: {
         maxBackoff: "1 second"
       }
       debounceCheckpoints: "10 seconds"
+      maxRetries: 10
     }
   }
 

--- a/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSourceConfig.scala
+++ b/modules/kinesis/src/main/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSourceConfig.scala
@@ -51,7 +51,8 @@ case class KinesisSourceConfig(
   leaseDuration: FiniteDuration,
   maxLeasesToStealAtOneTimeFactor: BigDecimal,
   checkpointThrottledBackoffPolicy: BackoffPolicy,
-  debounceCheckpoints: FiniteDuration
+  debounceCheckpoints: FiniteDuration,
+  maxRetries: Int
 )
 
 object KinesisSourceConfig {

--- a/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSourceConfigSpec.scala
+++ b/modules/kinesis/src/test/scala/com/snowplowanalytics/snowplow/streams/kinesis/KinesisSourceConfigSpec.scala
@@ -45,7 +45,8 @@ class KinesisSourceConfigSpec extends Specification {
         "minBackoff": "100 millis",
         "maxBackoff": "1second"
       },
-      "debounceCheckpoints": "42 seconds"
+      "debounceCheckpoints": "42 seconds",
+      "maxRetries": 10
     }
     """
 
@@ -83,7 +84,8 @@ class KinesisSourceConfigSpec extends Specification {
         "minBackoff": "100 millis",
         "maxBackoff": "1second"
       },
-      "debounceCheckpoints": "42 seconds"
+      "debounceCheckpoints": "42 seconds",
+      "maxRetries": 10
     }
     """
 
@@ -127,7 +129,8 @@ class KinesisSourceConfigSpec extends Specification {
       leaseDuration                    = 10.seconds,
       maxLeasesToStealAtOneTimeFactor  = BigDecimal(2.0),
       checkpointThrottledBackoffPolicy = BackoffPolicy(minBackoff = 100.millis, maxBackoff = 1.second),
-      debounceCheckpoints              = 10.seconds
+      debounceCheckpoints              = 10.seconds,
+      maxRetries                       = 10
     )
 
     result.as[Wrapper] must beRight.like { case w: Wrapper =>


### PR DESCRIPTION
- Add configurable AWS SDK retry count for Kinesis source
- Increase the default SDK retry count from 3 to 10 for Kinesis, DynamoDB and CloudWatch clients used by KCL

ref: https://snplow.atlassian.net/browse/PDP-2325