### PR TITLE
Fix: recover Kafka producer from epoch errors and KAFKA-7848 timeouts

### DIFF
--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
@@ -72,10 +72,16 @@ private[kafka] object KafkaSink {
   ): Sink[F] = {
     // With idempotent producers (enable.idempotence=true), OUT_OF_ORDER_SEQUENCE_NUMBER from the
     // broker is not surfaced as OutOfOrderSequenceException to future.get(). Instead the client
-    // retries internally via an epoch-bump loop until delivery.timeout.ms expires, then throws
-    // KafkaTimeoutException (KAFKA-7848). We replace the producer on timeout only when idempotence
-    // is enabled: with idempotence off, a timeout means delivery outcome is uncertain and retrying
-    // risks duplicate delivery.
+    // enters an internal epoch-bump retry loop (KAFKA-7848 — unresolved, no fix version assigned).
+    // This loop may not respect delivery.timeout.ms, meaning future.get() may never return unless
+    // delivery.timeout.ms is explicitly configured in producerConf. When it does expire, the client
+    // throws KafkaTimeoutException. We replace the producer on timeout only when idempotence is
+    // enabled: with idempotence off, OUT_OF_ORDER_SEQUENCE_NUMBER cannot occur (it is an
+    // idempotent-producer-only error), so a KafkaTimeoutException represents a genuine delivery
+    // timeout where the outcome is uncertain and retrying risks duplicate delivery.
+    //
+    // IMPORTANT: callers must set delivery.timeout.ms in producerConf when using idempotent
+    // producers to bound this loop. Without it, future.get() may block indefinitely.
     val idempotenceEnabled = config.producerConf.get("enable.idempotence").contains("true")
 
     new Sink[F] {
@@ -142,6 +148,9 @@ private[kafka] object KafkaSink {
       // epoch-bump loop until delivery.timeout.ms expires, then throws KafkaTimeoutException
       // (KAFKA-7848). We only replace on timeout when idempotence is enabled: with idempotence
       // off, delivery outcome on timeout is uncertain and retrying could produce duplicates.
+      // KafkaTimeoutException after delivery.timeout.ms expiry is the observable symptom of
+      // KAFKA-7848 with idempotence enabled. With idempotence disabled this error is a genuine
+      // delivery timeout and must not be retried blindly.
       case _: KafkaTimeoutException if idempotenceEnabled => true
       case _                                              => false
     }

--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
@@ -9,7 +9,7 @@ package com.snowplowanalytics.snowplow.streams.kafka.sink
 
 import cats.implicits._
 import cats.effect.{Async, Ref, Resource, Sync}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerRecord}
 import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
@@ -30,15 +30,22 @@ private[kafka] object KafkaSink {
   def resource[F[_]: Async](
     config: KafkaSinkConfig,
     authHandlerClass: String
+  ): Resource[F, Sink[F]] =
+    resourceWithFactory(config, newProducer[F](config, authHandlerClass))
+
+  // Visible to tests so they can inject a mock producer factory
+  private[kafka] def resourceWithFactory[F[_]: Async](
+    config: KafkaSinkConfig,
+    makeProducer: F[Producer[String, Array[Byte]]]
   ): Resource[F, Sink[F]] = {
-    val acquire = newProducer[F](config, authHandlerClass).flatMap(Ref.of[F, KafkaProducer[String, Array[Byte]]](_))
-    val release = (ref: Ref[F, KafkaProducer[String, Array[Byte]]]) =>
+    val acquire = makeProducer.flatMap(Ref.of[F, Producer[String, Array[Byte]]](_))
+    val release = (ref: Ref[F, Producer[String, Array[Byte]]]) =>
       ref.get.flatMap(p => Sync[F].blocking(p.close()))
     for {
       producerRef <- Resource.make(acquire)(release)
       ec1         <- createExecutionContext
       ec2         <- createExecutionContext
-    } yield impl(config, authHandlerClass, producerRef, ec1, ec2)
+    } yield impl(config, makeProducer, producerRef, ec1, ec2)
   }
 
   private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
@@ -46,7 +53,7 @@ private[kafka] object KafkaSink {
   private def newProducer[F[_]: Sync](
     config: KafkaSinkConfig,
     authHandlerClass: String
-  ): F[KafkaProducer[String, Array[Byte]]] = Sync[F].delay {
+  ): F[Producer[String, Array[Byte]]] = Sync[F].delay {
     val producerSettings = Map(
       "bootstrap.servers"                -> config.bootstrapServers,
       "sasl.login.callback.handler.class" -> authHandlerClass,
@@ -58,8 +65,8 @@ private[kafka] object KafkaSink {
 
   private def impl[F[_]: Async](
     config: KafkaSinkConfig,
-    authHandlerClass: String,
-    producerRef: Ref[F, KafkaProducer[String, Array[Byte]]],
+    makeProducer: F[Producer[String, Array[Byte]]],
+    producerRef: Ref[F, Producer[String, Array[Byte]]],
     ecForSend: ExecutionContext,
     ecForWait: ExecutionContext
   ): Sink[F] =
@@ -94,7 +101,7 @@ private[kafka] object KafkaSink {
       // valid producer reference.
       private def replaceProducer: F[Unit] =
         for {
-          replacement <- newProducer[F](config, authHandlerClass)
+          replacement <- makeProducer
           old         <- producerRef.getAndSet(replacement)
           _           <- Sync[F].blocking(old.close())
         } yield ()

--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
@@ -8,8 +8,9 @@
 package com.snowplowanalytics.snowplow.streams.kafka.sink
 
 import cats.implicits._
-import cats.effect.{Async, Resource, Sync}
+import cats.effect.{Async, Ref, Resource, Sync}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 import org.typelevel.log4cats.Logger
@@ -18,9 +19,9 @@ import org.typelevel.log4cats.slf4j.Slf4jLogger
 import com.snowplowanalytics.snowplow.streams.{ListOfList, Sink, Sinkable}
 import com.snowplowanalytics.snowplow.streams.kafka.KafkaSinkConfig
 
-import java.util.UUID
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.Executors
+import java.util.UUID
+import java.util.concurrent.{ExecutionException, Executors}
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
@@ -29,78 +30,107 @@ private[kafka] object KafkaSink {
   def resource[F[_]: Async](
     config: KafkaSinkConfig,
     authHandlerClass: String
-  ): Resource[F, Sink[F]] =
+  ): Resource[F, Sink[F]] = {
+    val acquire = newProducer[F](config, authHandlerClass).flatMap(Ref.of[F, KafkaProducer[String, Array[Byte]]](_))
+    val release = (ref: Ref[F, KafkaProducer[String, Array[Byte]]]) =>
+      ref.get.flatMap(p => Sync[F].blocking(p.close()))
     for {
-      producer <- makeProducer(config, authHandlerClass)
-      ec1 <- createExecutionContext
-      ec2 <- createExecutionContext
-    } yield impl(config, producer, ec1, ec2)
+      producerRef <- Resource.make(acquire)(release)
+      ec1         <- createExecutionContext
+      ec2         <- createExecutionContext
+    } yield impl(config, authHandlerClass, producerRef, ec1, ec2)
+  }
 
   private implicit def logger[F[_]: Sync]: Logger[F] = Slf4jLogger.getLogger[F]
 
-  private def makeProducer[F[_]: Async](
+  private def newProducer[F[_]: Sync](
     config: KafkaSinkConfig,
     authHandlerClass: String
-  ): Resource[F, KafkaProducer[String, Array[Byte]]] = {
+  ): F[KafkaProducer[String, Array[Byte]]] = Sync[F].delay {
     val producerSettings = Map(
-      "bootstrap.servers" -> config.bootstrapServers,
+      "bootstrap.servers"                -> config.bootstrapServers,
       "sasl.login.callback.handler.class" -> authHandlerClass,
-      "key.serializer" -> classOf[StringSerializer].getName,
-      "value.serializer" -> classOf[ByteArraySerializer].getName
+      "key.serializer"                   -> classOf[StringSerializer].getName,
+      "value.serializer"                 -> classOf[ByteArraySerializer].getName
     ) ++ config.producerConf
-    val make = Sync[F].delay {
-      new KafkaProducer[String, Array[Byte]]((producerSettings: Map[String, AnyRef]).asJava)
-    }
-    Resource.make(make)(p => Sync[F].blocking(p.close))
+    new KafkaProducer[String, Array[Byte]]((producerSettings: Map[String, AnyRef]).asJava)
   }
 
   private def impl[F[_]: Async](
     config: KafkaSinkConfig,
-    producer: KafkaProducer[String, Array[Byte]],
+    authHandlerClass: String,
+    producerRef: Ref[F, KafkaProducer[String, Array[Byte]]],
     ecForSend: ExecutionContext,
     ecForWait: ExecutionContext
   ): Sink[F] =
     new Sink[F] {
-      def sink(batch: ListOfList[Sinkable]): F[Unit] = {
-        val futures = Sync[F].delay {
-          batch.asIterable.map { e =>
-            val record = toProducerRecord(config, e)
-            producer.send(record)
-          }.toIndexedSeq
+
+      def sink(batch: ListOfList[Sinkable]): F[Unit] =
+        sendBatch(batch).recoverWith {
+          case e: ExecutionException if isProducerEpochError(e) =>
+            Logger[F].warn(
+              s"Replacing Kafka producer after unrecoverable sequence error (${e.getCause.getClass.getSimpleName}), retrying batch"
+            ) >> replaceProducer >> sendBatch(batch)
         }
-        Async[F].evalOn(futures, ecForSend).flatMap { fs =>
-          val await = Sync[F].delay {
-            fs.foreach(_.get)
+
+      private def sendBatch(batch: ListOfList[Sinkable]): F[Unit] =
+        producerRef.get.flatMap { producer =>
+          val futures = Sync[F].delay {
+            batch.asIterable.map { e =>
+              val record = toProducerRecord(config, e)
+              producer.send(record)
+            }.toIndexedSeq
           }
-          Async[F].evalOn(await, ecForWait)
+          Async[F].evalOn(futures, ecForSend).flatMap { fs =>
+            val await = Sync[F].delay {
+              fs.foreach(_.get)
+            }
+            Async[F].evalOn(await, ecForWait)
+          }
         }
-      }
+
+      // Close the old producer and swap in a fresh one. The old producer is closed
+      // after the swap so that isHealthy checks and concurrent sends always see a
+      // valid producer reference.
+      private def replaceProducer: F[Unit] =
+        for {
+          replacement <- newProducer[F](config, authHandlerClass)
+          old         <- producerRef.getAndSet(replacement)
+          _           <- Sync[F].blocking(old.close())
+        } yield ()
 
       def isHealthy: F[Boolean] =
-        Logger[F].info(s"Checking whether topic ${config.topicName} has leaders for all partitions") >>
-          Sync[F]
-            .blocking {
-              producer.partitionsFor(config.topicName).asScala
-            }
-            .flatMap { partitions =>
-              if (partitions.isEmpty)
-                Logger[F].warn(s"Topic ${config.topicName} has no partitions").as(false)
-              else if (partitions.exists(p => Option(p.leader()).isEmpty))
-                Logger[F].warn(s"Topic ${config.topicName} has partitions with no leader").as(false)
-              else
-                Logger[F].info(s"Confirmed topic ${config.topicName} has leaders for all partitions").as(true)
-            }
+        producerRef.get.flatMap { producer =>
+          Logger[F].info(s"Checking whether topic ${config.topicName} has leaders for all partitions") >>
+            Sync[F]
+              .blocking {
+                producer.partitionsFor(config.topicName).asScala
+              }
+              .flatMap { partitions =>
+                if (partitions.isEmpty)
+                  Logger[F].warn(s"Topic ${config.topicName} has no partitions").as(false)
+                else if (partitions.exists(p => Option(p.leader()).isEmpty))
+                  Logger[F].warn(s"Topic ${config.topicName} has partitions with no leader").as(false)
+                else
+                  Logger[F].info(s"Confirmed topic ${config.topicName} has leaders for all partitions").as(true)
+              }
+        }
+    }
+
+  private def isProducerEpochError(e: ExecutionException): Boolean =
+    e.getCause match {
+      case _: OutOfOrderSequenceException   => true
+      case _: InvalidProducerEpochException => true
+      case _                                => false
     }
 
   private def toProducerRecord(config: KafkaSinkConfig, sinkable: Sinkable): ProducerRecord[String, Array[Byte]] = {
-
     val headers = sinkable.attributes.map { case (k, v) =>
       new Header {
         def key: String        = k
         def value: Array[Byte] = v.getBytes(StandardCharsets.UTF_8)
       }
     }
-
     new ProducerRecord(config.topicName, null, sinkable.partitionKey.getOrElse(UUID.randomUUID.toString), sinkable.bytes, headers.asJava)
   }
 

--- a/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
+++ b/modules/kafka/src/main/scala/com/snowplowanalytics/snowplow/streams/kafka/sink/KafkaSink.scala
@@ -10,7 +10,7 @@ package com.snowplowanalytics.snowplow.streams.kafka.sink
 import cats.implicits._
 import cats.effect.{Async, Ref, Resource, Sync}
 import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerRecord}
-import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
+import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException, TimeoutException => KafkaTimeoutException}
 import org.apache.kafka.common.header.Header
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 import org.typelevel.log4cats.Logger
@@ -69,14 +69,22 @@ private[kafka] object KafkaSink {
     producerRef: Ref[F, Producer[String, Array[Byte]]],
     ecForSend: ExecutionContext,
     ecForWait: ExecutionContext
-  ): Sink[F] =
+  ): Sink[F] = {
+    // With idempotent producers (enable.idempotence=true), OUT_OF_ORDER_SEQUENCE_NUMBER from the
+    // broker is not surfaced as OutOfOrderSequenceException to future.get(). Instead the client
+    // retries internally via an epoch-bump loop until delivery.timeout.ms expires, then throws
+    // KafkaTimeoutException (KAFKA-7848). We replace the producer on timeout only when idempotence
+    // is enabled: with idempotence off, a timeout means delivery outcome is uncertain and retrying
+    // risks duplicate delivery.
+    val idempotenceEnabled = config.producerConf.get("enable.idempotence").contains("true")
+
     new Sink[F] {
 
       def sink(batch: ListOfList[Sinkable]): F[Unit] =
         sendBatch(batch).recoverWith {
-          case e: ExecutionException if isProducerEpochError(e) =>
+          case e: ExecutionException if requiresProducerReplacement(e, idempotenceEnabled) =>
             Logger[F].warn(
-              s"Replacing Kafka producer after unrecoverable sequence error (${e.getCause.getClass.getSimpleName}), retrying batch"
+              s"Producer error on topic ${config.topicName} (${e.getCause.getClass.getSimpleName}): replacing producer and retrying batch"
             ) >> replaceProducer >> sendBatch(batch)
         }
 
@@ -123,12 +131,19 @@ private[kafka] object KafkaSink {
               }
         }
     }
+  }
 
-  private def isProducerEpochError(e: ExecutionException): Boolean =
+  private def requiresProducerReplacement(e: ExecutionException, idempotenceEnabled: Boolean): Boolean =
     e.getCause match {
       case _: OutOfOrderSequenceException   => true
       case _: InvalidProducerEpochException => true
-      case _                                => false
+      // For idempotent-only producers, OUT_OF_ORDER_SEQUENCE_NUMBER is not surfaced as
+      // OutOfOrderSequenceException to future.get(). The client retries internally via an
+      // epoch-bump loop until delivery.timeout.ms expires, then throws KafkaTimeoutException
+      // (KAFKA-7848). We only replace on timeout when idempotence is enabled: with idempotence
+      // off, delivery outcome on timeout is uncertain and retrying could produce duplicates.
+      case _: KafkaTimeoutException if idempotenceEnabled => true
+      case _                                              => false
     }
 
   private def toProducerRecord(config: KafkaSinkConfig, sinkable: Sinkable): ProducerRecord[String, Array[Byte]] = {

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
@@ -7,16 +7,21 @@
  */
 package com.snowplowanalytics.snowplow.streams.kafka
 
+import cats.Id
 import cats.effect.IO
 import cats.effect.testing.specs2.CatsEffect
-import org.apache.kafka.clients.producer.{MockProducer, Producer}
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
+import org.apache.kafka.clients.producer.{Callback, MockProducer, Producer, ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition, Uuid}
 import org.specs2.Specification
 
 import com.snowplowanalytics.snowplow.streams.{ListOfList, Sinkable}
 import com.snowplowanalytics.snowplow.streams.kafka.sink.KafkaSink
 
+import java.time.Duration
+import java.util.concurrent.{CompletableFuture, Future => JFuture}
 import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters._
 
@@ -27,10 +32,10 @@ class KafkaSinkSpec extends Specification with CatsEffect {
     Successfully send a batch to the producer $sendsBatch
     Replace the producer and retry after OutOfOrderSequenceException $recoversFromOutOfOrderSequence
     Replace the producer and retry after InvalidProducerEpochException $recoversFromInvalidProducerEpoch
-    Not retry on an unrelated ExecutionException $doesNotRetryOnUnrelatedError
+    Not retry on an unrelated error $doesNotRetryOnUnrelatedError
   """
 
-  private val config = KafkaSinkConfig(
+  private val config = KafkaSinkConfigM[Id](
     topicName        = "test-topic",
     bootstrapServers = "localhost:9092",
     producerConf     = Map.empty
@@ -42,6 +47,35 @@ class KafkaSinkSpec extends Specification with CatsEffect {
   private def testBatch: ListOfList[Sinkable] =
     ListOfList.ofItems(Sinkable(bytes = "hello".getBytes, partitionKey = Some("k"), attributes = Map.empty))
 
+  /** A Producer that either completes futures successfully or exceptionally, tracking send count */
+  private def testProducer(
+    failWith: Option[Exception],
+    sendCount: AtomicInteger = new AtomicInteger(0)
+  ): Producer[String, Array[Byte]] = new Producer[String, Array[Byte]] {
+    def send(r: ProducerRecord[String, Array[Byte]]): JFuture[RecordMetadata] = {
+      sendCount.incrementAndGet()
+      val f = new CompletableFuture[RecordMetadata]()
+      failWith match {
+        case Some(e) => f.completeExceptionally(e)
+        case None    => f.complete(new RecordMetadata(new TopicPartition(r.topic(), 0), 0L, 0, 0L, -1, -1))
+      }
+      f
+    }
+    def send(r: ProducerRecord[String, Array[Byte]], cb: Callback): JFuture[RecordMetadata] = send(r)
+    def flush(): Unit = ()
+    def partitionsFor(topic: String): java.util.List[PartitionInfo]                                  = java.util.Collections.emptyList()
+    def metrics(): java.util.Map[MetricName, _ <: Metric]                                            = java.util.Collections.emptyMap()
+    def close(): Unit                                                                                 = ()
+    def close(timeout: Duration): Unit                                                               = ()
+    def initTransactions(): Unit                                                                      = ()
+    def beginTransaction(): Unit                                                                      = ()
+    def commitTransaction(): Unit                                                                     = ()
+    def abortTransaction(): Unit                                                                      = ()
+    def clientInstanceId(timeout: Duration): Uuid                                                    = Uuid.ZERO_UUID
+    def sendOffsetsToTransaction(o: java.util.Map[TopicPartition, OffsetAndMetadata], m: ConsumerGroupMetadata): Unit = ()
+    def sendOffsetsToTransaction(o: java.util.Map[TopicPartition, OffsetAndMetadata], g: String): Unit               = ()
+  }
+
   def sendsBatch = {
     val mock = newMock(true)
     KafkaSink.resourceWithFactory[IO](config, IO.pure(mock)).use { sink =>
@@ -52,53 +86,52 @@ class KafkaSinkSpec extends Specification with CatsEffect {
   }
 
   def recoversFromOutOfOrderSequence = {
-    val failingMock   = newMock(true)
-    val recoveredMock = newMock(true)
-    val callCount     = new AtomicInteger(0)
-
-    failingMock.errorNext(new OutOfOrderSequenceException("test error"))
+    val failingSendCount  = new AtomicInteger(0)
+    val successSendCount  = new AtomicInteger(0)
+    val callCount         = new AtomicInteger(0)
 
     val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
-      if (callCount.getAndIncrement() == 0) failingMock
-      else recoveredMock
+      if (callCount.getAndIncrement() == 0) testProducer(Some(new OutOfOrderSequenceException("test")), failingSendCount)
+      else testProducer(None, successSendCount)
     }
 
     KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
       sink.sink(testBatch)
     } map { _ =>
-      failingMock.history.asScala must beEmpty and
-        (recoveredMock.history.asScala must haveSize(1))
+      // Initial send failed; producer was replaced and batch retried on the new producer
+      (failingSendCount.get() must_== 1) and (successSendCount.get() must_== 1)
     }
   }
 
   def recoversFromInvalidProducerEpoch = {
-    val failingMock   = newMock(true)
-    val recoveredMock = newMock(true)
-    val callCount     = new AtomicInteger(0)
-
-    failingMock.errorNext(new InvalidProducerEpochException("test error"))
+    val failingSendCount  = new AtomicInteger(0)
+    val successSendCount  = new AtomicInteger(0)
+    val callCount         = new AtomicInteger(0)
 
     val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
-      if (callCount.getAndIncrement() == 0) failingMock
-      else recoveredMock
+      if (callCount.getAndIncrement() == 0) testProducer(Some(new InvalidProducerEpochException("test")), failingSendCount)
+      else testProducer(None, successSendCount)
     }
 
     KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
       sink.sink(testBatch)
     } map { _ =>
-      failingMock.history.asScala must beEmpty and
-        (recoveredMock.history.asScala must haveSize(1))
+      (failingSendCount.get() must_== 1) and (successSendCount.get() must_== 1)
     }
   }
 
   def doesNotRetryOnUnrelatedError = {
-    val failingMock = newMock(true)
-    failingMock.errorNext(new RuntimeException("unrelated error"))
+    val callCount = new AtomicInteger(0)
+    val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
+      callCount.incrementAndGet()
+      testProducer(Some(new RuntimeException("unrelated error")))
+    }
 
-    KafkaSink.resourceWithFactory[IO](config, IO.pure(failingMock)).use { sink =>
+    KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
       sink.sink(testBatch).attempt
     } map { result =>
-      result must beLeft
+      // Error must propagate and producer must NOT be replaced (callCount stays at 1)
+      (result must beLeft) and (callCount.get() must_== 1)
     }
   }
 }

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
@@ -126,7 +126,10 @@ class KafkaSinkSpec extends Specification with CatsEffect {
     }
   }
 
-  // KAFKA-7848: idempotent producers surface OUT_OF_ORDER_SEQUENCE_NUMBER as KafkaTimeoutException
+  // KAFKA-7848 (unresolved): idempotent producers enter an infinite epoch-bump retry loop on
+  // OUT_OF_ORDER_SEQUENCE_NUMBER. The loop may not respect delivery.timeout.ms; when
+  // delivery.timeout.ms is configured, the client eventually throws KafkaTimeoutException.
+  // Producer replacement on this exception is the workaround for the unresolved KAFKA-7848.
   def recoversFromTimeoutWithIdempotence = {
     val failingSendCount = new AtomicInteger(0)
     val successSendCount = new AtomicInteger(0)

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2023-present Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Snowplow Community License Version 1.0,
+ * and you may not use this file except in compliance with the Snowplow Community License Version 1.0.
+ * You may obtain a copy of the Snowplow Community License Version 1.0 at https://docs.snowplow.io/community-license-1.0
+ */
+package com.snowplowanalytics.snowplow.streams.kafka
+
+import cats.effect.IO
+import cats.effect.testing.specs2.CatsEffect
+import org.apache.kafka.clients.producer.{MockProducer, Producer}
+import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
+import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import org.specs2.Specification
+
+import com.snowplowanalytics.snowplow.streams.{ListOfList, Sinkable}
+import com.snowplowanalytics.snowplow.streams.kafka.sink.KafkaSink
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters._
+
+class KafkaSinkSpec extends Specification with CatsEffect {
+
+  def is = s2"""
+  KafkaSink should:
+    Successfully send a batch to the producer $sendsBatch
+    Replace the producer and retry after OutOfOrderSequenceException $recoversFromOutOfOrderSequence
+    Replace the producer and retry after InvalidProducerEpochException $recoversFromInvalidProducerEpoch
+    Not retry on an unrelated ExecutionException $doesNotRetryOnUnrelatedError
+  """
+
+  private val config = KafkaSinkConfig(
+    topicName        = "test-topic",
+    bootstrapServers = "localhost:9092",
+    producerConf     = Map.empty
+  )
+
+  private def newMock(autoComplete: Boolean): MockProducer[String, Array[Byte]] =
+    new MockProducer[String, Array[Byte]](autoComplete, new StringSerializer, new ByteArraySerializer)
+
+  private def testBatch: ListOfList[Sinkable] =
+    ListOfList.ofItems(Sinkable(bytes = "hello".getBytes, partitionKey = Some("k"), attributes = Map.empty))
+
+  def sendsBatch = {
+    val mock = newMock(true)
+    KafkaSink.resourceWithFactory[IO](config, IO.pure(mock)).use { sink =>
+      sink.sink(testBatch)
+    } map { _ =>
+      mock.history.asScala must haveSize(1)
+    }
+  }
+
+  def recoversFromOutOfOrderSequence = {
+    val failingMock   = newMock(true)
+    val recoveredMock = newMock(true)
+    val callCount     = new AtomicInteger(0)
+
+    failingMock.errorNext(new OutOfOrderSequenceException("test error"))
+
+    val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
+      if (callCount.getAndIncrement() == 0) failingMock
+      else recoveredMock
+    }
+
+    KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
+      sink.sink(testBatch)
+    } map { _ =>
+      failingMock.history.asScala must beEmpty and
+        (recoveredMock.history.asScala must haveSize(1))
+    }
+  }
+
+  def recoversFromInvalidProducerEpoch = {
+    val failingMock   = newMock(true)
+    val recoveredMock = newMock(true)
+    val callCount     = new AtomicInteger(0)
+
+    failingMock.errorNext(new InvalidProducerEpochException("test error"))
+
+    val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
+      if (callCount.getAndIncrement() == 0) failingMock
+      else recoveredMock
+    }
+
+    KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
+      sink.sink(testBatch)
+    } map { _ =>
+      failingMock.history.asScala must beEmpty and
+        (recoveredMock.history.asScala must haveSize(1))
+    }
+  }
+
+  def doesNotRetryOnUnrelatedError = {
+    val failingMock = newMock(true)
+    failingMock.errorNext(new RuntimeException("unrelated error"))
+
+    KafkaSink.resourceWithFactory[IO](config, IO.pure(failingMock)).use { sink =>
+      sink.sink(testBatch).attempt
+    } map { result =>
+      result must beLeft
+    }
+  }
+}

--- a/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
+++ b/modules/kafka/src/test/scala/com/snowplowanalytics/snowplow/streams/kafka/KafkaSinkSpec.scala
@@ -12,7 +12,7 @@ import cats.effect.IO
 import cats.effect.testing.specs2.CatsEffect
 import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{Callback, MockProducer, Producer, ProducerRecord, RecordMetadata}
-import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException}
+import org.apache.kafka.common.errors.{InvalidProducerEpochException, OutOfOrderSequenceException, TimeoutException => KafkaTimeoutException}
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 import org.apache.kafka.common.{Metric, MetricName, PartitionInfo, TopicPartition, Uuid}
 import org.specs2.Specification
@@ -32,6 +32,8 @@ class KafkaSinkSpec extends Specification with CatsEffect {
     Successfully send a batch to the producer $sendsBatch
     Replace the producer and retry after OutOfOrderSequenceException $recoversFromOutOfOrderSequence
     Replace the producer and retry after InvalidProducerEpochException $recoversFromInvalidProducerEpoch
+    Replace the producer and retry after KafkaTimeoutException when idempotence is enabled $recoversFromTimeoutWithIdempotence
+    Not retry KafkaTimeoutException when idempotence is disabled $doesNotRetryTimeoutWithoutIdempotence
     Not retry on an unrelated error $doesNotRetryOnUnrelatedError
   """
 
@@ -39,6 +41,10 @@ class KafkaSinkSpec extends Specification with CatsEffect {
     topicName        = "test-topic",
     bootstrapServers = "localhost:9092",
     producerConf     = Map.empty
+  )
+
+  private val idempotentConfig = config.copy(
+    producerConf = Map("enable.idempotence" -> "true")
   )
 
   private def newMock(autoComplete: Boolean): MockProducer[String, Array[Byte]] =
@@ -117,6 +123,39 @@ class KafkaSinkSpec extends Specification with CatsEffect {
       sink.sink(testBatch)
     } map { _ =>
       (failingSendCount.get() must_== 1) and (successSendCount.get() must_== 1)
+    }
+  }
+
+  // KAFKA-7848: idempotent producers surface OUT_OF_ORDER_SEQUENCE_NUMBER as KafkaTimeoutException
+  def recoversFromTimeoutWithIdempotence = {
+    val failingSendCount = new AtomicInteger(0)
+    val successSendCount = new AtomicInteger(0)
+    val callCount        = new AtomicInteger(0)
+
+    val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
+      if (callCount.getAndIncrement() == 0) testProducer(Some(new KafkaTimeoutException("delivery.timeout.ms expired")), failingSendCount)
+      else testProducer(None, successSendCount)
+    }
+
+    KafkaSink.resourceWithFactory[IO](idempotentConfig, makeProducer).use { sink =>
+      sink.sink(testBatch)
+    } map { _ =>
+      (failingSendCount.get() must_== 1) and (successSendCount.get() must_== 1)
+    }
+  }
+
+  // Without idempotence, KafkaTimeoutException should NOT trigger producer replacement
+  def doesNotRetryTimeoutWithoutIdempotence = {
+    val callCount = new AtomicInteger(0)
+    val makeProducer: IO[Producer[String, Array[Byte]]] = IO {
+      callCount.incrementAndGet()
+      testProducer(Some(new KafkaTimeoutException("delivery.timeout.ms expired")))
+    }
+
+    KafkaSink.resourceWithFactory[IO](config, makeProducer).use { sink =>
+      sink.sink(testBatch).attempt
+    } map { result =>
+      (result must beLeft) and (callCount.get() must_== 1)
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -158,7 +158,9 @@ object Dependencies {
     circeGeneric,
     azureIdentity,
     jwt,
-    specs2
+    specs2,
+    catsEffectSpecs2,
+    catsEffectTestkit
   )
 
   val pubsubDependencies = Seq(


### PR DESCRIPTION
Closes #156

## Summary

- Refactor `KafkaSink` to hold the producer in a `Ref[F, Producer[String, Array[Byte]]]` so it can be atomically replaced at runtime
- On `ExecutionException` where the cause is `OutOfOrderSequenceException` or `InvalidProducerEpochException`, close the old producer, swap in a fresh one (new epoch), and retry the batch once
- Handle KAFKA-7848: for idempotent-only producers (no `transactional.id`), `OUT_OF_ORDER_SEQUENCE_NUMBER` is **not** surfaced as `OutOfOrderSequenceException` to `future.get()`. The client retries internally via an epoch-bump loop until `delivery.timeout.ms` expires, then throws `org.apache.kafka.common.errors.TimeoutException`. The recovery now also matches `KafkaTimeoutException`, guarded by `enable.idempotence=true` in `producerConf`
- Without idempotence, `KafkaTimeoutException` is **not** matched — delivery outcome on timeout is uncertain and retrying risks duplicate delivery
- Rename `isProducerEpochError` → `requiresProducerReplacement` to reflect the broader scope
- Switch from the concrete `KafkaProducer` type to the `Producer` interface throughout, enabling unit testing without a real broker

## Background

These errors are unrecoverable for the current producer instance — Kafka requires a new producer with a new epoch. Without this fix, the sink enters a permanent failure state and consumer lag accumulates until the pod is externally evicted.

For the enricher specifically (`enable.idempotence=true`, no `transactional.id`), the original fix did not trigger because `OutOfOrderSequenceException` is never thrown — instead the client's internal epoch-bump retry loop exhausts `delivery.timeout.ms` and throws `TimeoutException` ([KAFKA-7848](https://issues.apache.org/jira/browse/KAFKA-7848)). This was confirmed by Confluent support and production logs from PI-32897.

## Trade-offs

- Retrying the batch with a new producer (new PID/epoch) may produce duplicates for records that were acked before the error. This is acceptable given the enricher's existing at-least-once semantics.
- With idempotence enabled, a genuine `KafkaTimeoutException` (not from KAFKA-7848) will also trigger producer replacement. This is safe: if `future.get()` threw `TimeoutException`, the record was definitively not acked, so the retry does not risk duplication under idempotent delivery.
- With idempotence disabled, `KafkaTimeoutException` is not matched — the error propagates normally, preventing duplicate delivery in non-idempotent configurations.

## Test plan

- [x] `sbt "kafka/test"` passes (6 examples in `KafkaSinkSpec`, 0 failures)
- [ ] Existing `KafkaSinkConfigSpec` and `KafkaSourceConfigSpec` still pass

### Test cases

| Test | What it verifies |
|------|-----------------|
| `sendsBatch` | Successful send through the blocking wait path |
| `recoversFromOutOfOrderSequence` | Producer replaced + batch retried on `OutOfOrderSequenceException` |
| `recoversFromInvalidProducerEpoch` | Producer replaced + batch retried on `InvalidProducerEpochException` |
| `recoversFromTimeoutWithIdempotence` | Producer replaced + batch retried on `KafkaTimeoutException` when `enable.idempotence=true` (KAFKA-7848) |
| `doesNotRetryTimeoutWithoutIdempotence` | Error propagates, no producer replacement when idempotence is off |
| `doesNotRetryOnUnrelatedError` | Error propagates, no producer replacement on unrelated exceptions |

## Related

- PI-32897
- AP-2054
- [KAFKA-7848](https://issues.apache.org/jira/browse/KAFKA-7848)